### PR TITLE
[ALS-6648] Update ExpandableRow store and components...

### DIFF
--- a/src/lib/components/datatable/Row.svelte
+++ b/src/lib/components/datatable/Row.svelte
@@ -1,25 +1,29 @@
 <script lang="ts">
   import type { Column } from '$lib/models/Tables';
   import type { Indexable } from '$lib/types';
-  import { activeRow, expandableComponents, activeComponent } from '$lib/stores/ExpandableRow';
+  import {
+    activeTable,
+    activeRow,
+    expandableComponents,
+    activeComponent,
+    setActiveRow,
+  } from '$lib/stores/ExpandableRow';
 
   export let cellOverides: Indexable = {};
   export let columns: Column[] = [];
   export let index: number = -2;
   export let row: Indexable = {};
-  export let rowClickHandler: (index: number, row?: Indexable) => void;
+  export let tableName: string = '';
+  export let rowClickHandler: (row: Indexable) => void = () => {};
 
-  function onClick(index: number, row: Indexable) {
-    if (index === undefined || index === null || index < 0) return;
-    rowClickHandler && rowClickHandler(index, row);
+  function onClick(row: Indexable) {
+    setActiveRow({ row: row.id, table: tableName });
+    rowClickHandler(row);
   }
+  $: active = $activeTable === tableName && $activeRow === row?.id;
 </script>
 
-<tr
-  id={index.toString()}
-  on:click|stopPropagation={() => onClick(index, row)}
-  class="cursor-pointer"
->
+<tr id={index.toString()} on:click|stopPropagation={() => onClick(row)} class="cursor-pointer">
   {#each columns as column}
     <td>
       {#if cellOverides[column.dataElement]}
@@ -34,7 +38,7 @@
   {/each}
 </tr>
 
-{#if Object.keys($expandableComponents).length > 0 && $activeRow === index}
+{#if active && Object.keys($expandableComponents).length > 0}
   <tr class="expandable-row">
     <td colspan={columns.length}>
       {#if $activeComponent}

--- a/src/lib/components/datatable/Table.svelte
+++ b/src/lib/components/datatable/Table.svelte
@@ -12,12 +12,13 @@
   import ExpandableRow from '$lib/components/datatable/Row.svelte';
 
   // Parameters
+  export let tableName: string;
   export let search = false;
   export let title = '';
   export let defaultRowsPerPage = 5;
   export let columns: Column[] = [];
   export let cellOverides: Indexable = {};
-  export let rowClickHandler: (index: number, row?: Indexable) => void = () => {};
+  export let rowClickHandler: (row: Indexable) => void = () => {};
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export let data: any = []; //TODO: Fix this type
@@ -64,7 +65,7 @@
     <tbody>
       {#if $rows.length > 0}
         {#each $rows as row, i}
-          <ExpandableRow {cellOverides} {columns} index={i} {row} {rowClickHandler} />
+          <ExpandableRow {tableName} {cellOverides} {columns} index={i} {row} {rowClickHandler} />
         {/each}
       {:else}
         <tr><td colspan={columns.length}>No entries found.</td></tr>

--- a/src/lib/components/explorer/AddFilter.svelte
+++ b/src/lib/components/explorer/AddFilter.svelte
@@ -78,7 +78,7 @@
   }
 
   function finish() {
-    $activeRow = -1;
+    $activeRow = '';
     if ($modalStore[0]) {
       modalStore.close();
     }

--- a/src/lib/components/explorer/cell/Actions.svelte
+++ b/src/lib/components/explorer/cell/Actions.svelte
@@ -9,7 +9,6 @@
     variableName: data.row.name,
     variableId: data.row.id,
   };
-  // const tableName = 'ExplorerTable';
   function updateActiveRow(component: string) {
     return () => {
       setActiveRow({

--- a/src/lib/components/explorer/cell/Actions.svelte
+++ b/src/lib/components/explorer/cell/Actions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SearchResult } from '$lib/models/Search';
-  import { activeRow, expandableComponents, activeComponent } from '$lib/stores/ExpandableRow';
+  import { activeTable, expandableComponents, setActiveRow } from '$lib/stores/ExpandableRow';
   import type { Export } from '$lib/models/Export';
   import ExportStore from '$lib/stores/Export';
   let { exports, addExport, removeExport } = ExportStore;
@@ -9,25 +9,21 @@
     variableName: data.row.name,
     variableId: data.row.id,
   };
+  // const tableName = 'ExplorerTable';
   function updateActiveRow(component: string) {
-    if ($activeRow === data.index && $activeComponent === $expandableComponents[component]) {
-      activeRow.set(-1);
-      return;
-    }
-    (data.index !== undefined || data.index !== null) && activeRow.set(data.index);
+    return () => {
+      setActiveRow({
+        row: data.row.id,
+        component: $expandableComponents[component],
+        table: $activeTable,
+      });
+    };
   }
-  function insertInfoContent() {
-    updateActiveRow('info');
-    activeComponent.set($expandableComponents['info']);
-  }
-  function insertFilterContent() {
-    updateActiveRow('filter');
-    activeComponent.set($expandableComponents['filter']);
-  }
-  function insertHierarchyContent() {
-    updateActiveRow('hierarchy');
-    activeComponent.set($expandableComponents['hierarchy']);
-  }
+
+  const insertInfoContent = updateActiveRow('info');
+  const insertFilterContent = updateActiveRow('filter');
+  const insertHierarchyContent = updateActiveRow('hierarchy');
+
   function insertExportContent() {
     if ($exports.includes(exported)) {
       removeExport(exported.variableId);

--- a/src/lib/stores/ExpandableRow.ts
+++ b/src/lib/stores/ExpandableRow.ts
@@ -1,6 +1,42 @@
 import type { SvelteComponent } from 'svelte';
-import { writable, type Writable } from 'svelte/store';
+import { get, writable, type Writable } from 'svelte/store';
 
-export const activeRow: Writable<number> = writable(-1);
+export const activeTable: Writable<string> = writable('');
+export const activeRow: Writable<string> = writable('');
 export const expandableComponents: Writable<Record<string, typeof SvelteComponent>> = writable({});
-export const activeComponent: Writable<typeof SvelteComponent> = writable();
+export const defaultComponent: Writable<typeof SvelteComponent | undefined> = writable();
+export const activeComponent: Writable<typeof SvelteComponent | undefined> = writable();
+
+export function setActiveRow(options: {
+  row: string;
+  component?: typeof SvelteComponent;
+  table?: string;
+}) {
+  const { row, table, component } = options;
+  const sameRow = get(activeRow) === row;
+  const sameComponent = !component || get(activeComponent) === component;
+  const sameTable = !table || get(activeTable) === table;
+
+  if (sameRow && sameComponent && sameTable) {
+    activeRow.set('');
+    activeComponent.set(get(defaultComponent));
+  } else {
+    activeRow.set(row);
+    table && activeTable.set(table);
+    component && activeComponent.set(component);
+  }
+}
+
+// TODO: Bug? Why not typeof SvelteComponent?
+export function setComponentRegistry(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registry: Record<string, new (...args: any[]) => SvelteComponent>,
+  component?: string,
+  table?: string,
+) {
+  activeTable.set(table ? table : '');
+  activeRow.set('');
+  expandableComponents.set(registry);
+  defaultComponent.set(component ? registry[component] : undefined);
+  activeComponent.set(component ? registry[component] : undefined);
+}

--- a/src/routes/(picsure)/(authorized)/(admin)/admin/authorization/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/(admin)/admin/authorization/+page.svelte
@@ -47,7 +47,7 @@
     await loadApplications();
   }
 
-  const rowClickHandler = (path: string) => (_index: number, row?: Indexable) => {
+  const rowClickHandler = (path: string) => (row: Indexable) => {
     const uuid = row?.uuid;
     goto(`/admin/authorization/${path}/${uuid}`);
   };
@@ -78,6 +78,7 @@
         </div>
       </div>
       <Datatable
+        tableName="Roles"
         data={$roles}
         columns={roleTable.columns}
         cellOverides={roleTable.overrides}
@@ -99,6 +100,7 @@
         </div>
       </div>
       <Datatable
+        tableName="Privileges"
         data={$privileges}
         columns={privilegesTable.columns}
         cellOverides={privilegesTable.overrides}

--- a/src/routes/(picsure)/(authorized)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/(admin)/admin/users/+page.svelte
@@ -73,7 +73,7 @@
     });
   }
 
-  const rowClickHandler = (_index: number, row?: Indexable) => {
+  const rowClickHandler = (row: Indexable) => {
     const uuid = row?.uuid;
     goto(`/admin/users/${uuid}`);
   };
@@ -101,6 +101,7 @@
     {#each $usersByConnection as connection}
       <div id={`user-table-${connection.label.replaceAll(' ', '_')}`} class="mb-10">
         <Datatable
+          tableName="Users"
           data={connection.users}
           {columns}
           {cellOverides}

--- a/src/routes/(picsure)/(authorized)/dataset/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/dataset/+page.svelte
@@ -28,7 +28,7 @@
 
   let displayArchived = false;
 
-  const rowClickHandler = (_index: number, row?: Indexable) => {
+  const rowClickHandler = (row: Indexable) => {
     const uuid = row?.uuid;
     goto(`/dataset/${uuid}`);
   };
@@ -44,10 +44,16 @@
     <ProgressBar animIndeterminate="anim-progress-bar" />
   {:then}
     <h3 class="text-left">Active Datasets</h3>
-    <Datatable data={$active} {columns} {cellOverides} {rowClickHandler} />
+    <Datatable
+      tableName="ActiveDatasets"
+      data={$active}
+      {columns}
+      {cellOverides}
+      {rowClickHandler}
+    />
     {#if displayArchived}
       <h3 class="text-left mt-5">Archived Datasets</h3>
-      <Datatable data={$archived} {columns} {cellOverides} />
+      <Datatable tableName="ArchivedDatasets" data={$archived} {columns} {cellOverides} />
     {/if}
     <button
       data-testid="dataset-toggle-archive"


### PR DESCRIPTION
- Update ExpandableRow store and components to specify unique row identifier and table.

**Notes:**
The new changes require each row to have access to a unique id. So, to use ExpandableRow with a table, make sure that you're passing down an id field in the column definition and setting the component registry on mount/unmount, like below. The row is still calling the rowClickHandler after it sets row & table id states, for further processing (for tables like Dataset or Users tables, which only require a redirect on row click and do not utilize the ExpandableRow feature).
```
onMount(() => {
    setComponentRegistry(
      {
        filter: AddFilterComponent,
        info: ResultInfoComponent,
        hierarchy: HierarchyComponent,
      },
      'info',
      tableName,
    );

    return () => {
      setComponentRegistry({});
    };
  });
```
