### PR TITLE
[ALS-6855] Show clear all filters and exports link, even with 0 participants

### DIFF
--- a/src/lib/components/explorer/results/ResultsPanel.svelte
+++ b/src/lib/components/explorer/results/ResultsPanel.svelte
@@ -72,10 +72,9 @@
     });
   }
 
-  $: showExportButton =
-    features.explorer.allowExport &&
-    totalPatients !== 0 &&
-    ($filters.length !== 0 || (features.explorer.exportsEnableExport && $exports.length !== 0));
+  $: hasFilterOrExport =
+    $filters.length !== 0 || (features.explorer.exportsEnableExport && $exports.length !== 0);
+  $: showExportButton = features.explorer.allowExport && totalPatients !== 0 && hasFilterOrExport;
 </script>
 
 <section
@@ -109,7 +108,7 @@
   <div class="flex flex-col items-center mt-8">
     <div class="flex content-center pb-2">
       <h5 class="font-bold text-lg flex-auto mr-2">Added to Export</h5>
-      {#if showExportButton}
+      {#if hasFilterOrExport}
         <button
           data-testid="clear-all-results-btn"
           class="anchor text-sm flex-none"
@@ -158,7 +157,7 @@
           <i class="fa-solid fa-chart-pie text-4xl"></i>
           <span>Variable Distributions</span>
         </button>
-        {#if features.explorer.variantExplorer && $hasGenomicFilter}
+        {#if totalPatients !== 0 && features.explorer.variantExplorer && $hasGenomicFilter}
           <button
             type="button"
             data-testid="variant-explorer-btn"

--- a/src/routes/(picsure)/(public)/explorer/variant/+page.svelte
+++ b/src/routes/(picsure)/(public)/explorer/variant/+page.svelte
@@ -131,6 +131,8 @@
             </div>
           </svelte:fragment>
         </Datatable>
+      {:else}
+        <div data-testid="variant-count" class="flex-none w-full">{$count} variants found</div>
       {/if}
     {:catch error}
       <ErrorAlert title="Error">

--- a/tests/routes/explorer/variant/test.ts
+++ b/tests/routes/explorer/variant/test.ts
@@ -79,6 +79,21 @@ test.describe('variant explorer', { tag: ['@feature', '@variantExplorer'] }, () 
       // Then
       await expect(download.suggestedFilename()).toBe('variantData.tsv');
     });
+    test("Displays count, even if it's 0", async ({ page }) => {
+      // When
+      await mockSyncAPI(page, {
+        ...successResults,
+        VARIANT_COUNT_FOR_QUERY: {
+          pass: true,
+          data: { count: 0, message: 'Query ran successfully' },
+        },
+      });
+      await page.locator('#results-panel').getByTestId('variant-explorer-btn').click();
+
+      // Then
+      await expect(page).toHaveURL('/explorer/variant');
+      await expect(page.getByTestId('variant-count')).toContainText('0');
+    });
     test('Error occurs during variant count retrieval', async ({ page }) => {
       // Given
       await mockSyncAPI(page, {


### PR DESCRIPTION
- Hide variant explorer button if there's 0 participants.
- Show variant count, even if it's 0.