### PR TITLE
[ALS-6742] Add Google Analytics and Tag Manager integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "auth0-js": "^9.24.1",
         "dotenv": "^16.4.5",
         "driver.js": "^1.3.1",
+        "gtagjs": "^0.0.10",
         "highlight.js": "^11.10.0",
         "plotly.js-dist-min": "^2.34.0",
         "svelte-eslint-parser": "^0.40.0",
@@ -3105,6 +3106,12 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/gtagjs": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/gtagjs/-/gtagjs-0.0.10.tgz",
+      "integrity": "sha512-b5FAp93DK5yVlXlHhMYzQo0+TRU/UURwTTg2hRn748Wd8Q7IqaoRJ3huihUsg9hhVoxlMzhGV2myV6Pn7PJWnA==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "highlight.js": "^11.10.0",
     "plotly.js-dist-min": "^2.34.0",
     "svelte-eslint-parser": "^0.40.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "gtagjs": "^0.0.10"
   }
 }

--- a/src/lib/assets/configuration.json
+++ b/src/lib/assets/configuration.json
@@ -159,5 +159,10 @@
         "consequence": "A standardized term from the Sequence Ontology (http://www.sequenceontology.org) to describe the calculated consequence of a variant. The severity for the calculated consequence of a variant on a gene has possible values HIGH (frameshift, splice disrupting, or truncating variants), MEDIUM (non-frameshift insertions or deletions, variants altering protein sequencing without affecting its length) or LOW (other coding variants including synonymous variants)."
       }
     }
+  },
+  "privacyPolicy": {
+    "title": "Privacy Policy",
+    "content": "This is the privacy policy for the PIC-SURE application.",
+    "url": "https://pic-sure.gitbook.io/pic-sure/privacy-policy"
   }
 }

--- a/src/lib/components/tracking/GoogleAnalytics.svelte
+++ b/src/lib/components/tracking/GoogleAnalytics.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { settings } from '$lib/configuration';
+  import { gtag } from 'gtagjs';
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  let googleAnalyticsID = settings.google.analytics;
+
+  $: {
+    if (browser && typeof gtag === 'function') {
+      console.debug('Tracking page view with Google Analytics');
+      // Send page view to Google Analytics
+      gtag('config', googleAnalyticsID, {
+        page_title: document.title,
+        page_path: $page.url.pathname,
+      });
+    }
+  }
+
+  const setupGoogleAnalytics = () => {
+    gtag('js', new Date());
+    gtag('config', googleAnalyticsID);
+
+    let consentMode = localStorage.getItem('consentMode');
+    if (!consentMode) {
+      // Default to deny all
+      gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        'analytics_storage': 'denied',
+        'personalization_storage': 'denied',
+        'security_storage': 'denied',
+        'ad_personalization': 'denied',
+        'ad_data': 'denied',
+      });
+    }
+  };
+
+  onMount(() => {
+    googleAnalyticsID && setupGoogleAnalytics();
+  });
+</script>
+<svelte:head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={googleAnalyticsID}">
+  </script>
+</svelte:head>

--- a/src/lib/components/tracking/GoogleConsents.svelte
+++ b/src/lib/components/tracking/GoogleConsents.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { gtag } from 'gtagjs';
+  import { branding } from '$lib/configuration';
+  $: googleConsentVisible = false;
+
+  function setUsersGoogleConsent(wasAccepted: boolean) {
+    let consent = {
+      'ad_storage': wasAccepted ? 'granted' : 'denied',
+      'analytics_storage': wasAccepted ? 'granted' : 'denied',
+      'personalization_storage': wasAccepted ? 'granted' : 'denied',
+      'security_storage': wasAccepted ? 'granted' : 'denied',
+      'ad_personalization': wasAccepted ? 'granted' : 'denied',
+      'ad_data': wasAccepted ? 'granted' : 'denied',
+    }
+
+    gtag('consent', 'default', consent);
+    localStorage.setItem('consentMode', JSON.stringify(consent));
+    googleConsentVisible = false;
+  }
+
+  onMount(() => {
+    console.debug("Google Consent Mode");
+    let consentMode = localStorage.getItem('consentMode');
+    if (!consentMode) {
+      googleConsentVisible = true;
+    }
+  });
+
+</script>
+{#if googleConsentVisible && branding?.privacyPolicy?.url && branding?.privacyPolicy?.title}
+  <div id="cookie-consent-container" class="fixed" style="left: 5%; bottom: 60px; z-index: 1000; width: 90%">
+    <div id="cookie-consent-banner" class="bg-surface-50-900-token p-4 rounded-container-token shadow-2xl">
+      <div class="flex flex-row justify-between items-center">
+        <div class="flex items center">
+          <p>We use cookies to provide you with the best possible experience and to help us make the site more useful to
+            visitors.
+            To learn more, please visit our <a href="{branding?.privacyPolicy?.url}" target="_blank" class="anchor">{branding?.privacyPolicy?.title}</a>.
+        </div>
+        <div class="flex flex-col justify-center">
+          <button class="btn variant-filled-primary mt-1 mb-1" on:click={() => setUsersGoogleConsent(true)}>Accept</button>
+          <button class="btn variant-ghost-primary mt-1 mb-1 self-center" on:click={() => setUsersGoogleConsent(false)}>Reject</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/tracking/GoogleTagManger.svelte
+++ b/src/lib/components/tracking/GoogleTagManger.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { settings } from '$lib/configuration';
+  import { onMount } from 'svelte';
+  let googleTag = settings.google.tagManager;
+
+  function setupDataLayer() {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ event: 'gtm.js', 'gtm.start': new Date().getTime() });
+  }
+
+  onMount(() => {
+    if (!googleTag) {
+      console.debug('Google Tag Manager ID is not set');
+      return;
+    }
+    console.debug('Google Tag Manager ID:', googleTag);
+    setupDataLayer();
+
+    let script = document.createElement('script');
+    script.src = `https://www.googletagmanager.com/gtm.js?id=${googleTag}&l=dataLayer`;
+    script.async = true;
+    document.head.appendChild(script);
+  });
+
+</script>

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -12,6 +12,7 @@ import type {
   LandingConfig,
   LoginConfig,
   SiteMapConfig,
+  PrivacyConfig,
 } from './types';
 
 export interface Branding {
@@ -27,6 +28,7 @@ export interface Branding {
   landing: LandingConfig;
   login: LoginConfig;
   help: HelpConfig;
+  privacyPolicy: PrivacyConfig;
 }
 
 export const branding: Branding = {
@@ -44,6 +46,7 @@ export const branding: Branding = {
   landing: {} as LandingConfig,
   login: {} as LoginConfig,
   help: {} as HelpConfig,
+  privacyPolicy: {} as PrivacyConfig,
 };
 
 export const initializeBranding = () => {
@@ -55,6 +58,7 @@ export const initializeBranding = () => {
   branding.help = configJson.help;
   branding.footer = configJson.footer;
   branding.sitemap = configJson.sitemap as SiteMapConfig[];
+  branding.privacyPolicy = configJson.privacyPolicy;
 };
 
 export const routes: Route[] = [
@@ -141,6 +145,10 @@ export const settings: Indexable = {
     graphColors: JSON.parse(
       import.meta.env?.VITE_DIST_EXPLORER_GRAPH_COLORS || '["#328FFF", "#675AFF", "#FFBC35"]',
     ),
+  },
+  google: {
+    analytics: import.meta.env?.VITE_GOOGLE_ANALYTICS_ID || '',
+    tagManager: import.meta.env?.VITE_GOOGLE_TAG_MANAGER_ID || '',
   },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,3 +80,9 @@ export interface HelpConfig {
   }>;
   popups: Indexable;
 }
+
+export interface PrivacyConfig {
+  title: string;
+  content: string;
+  url: string;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,10 +3,30 @@
   import '../app.postcss';
   import { initializeStores } from '@skeletonlabs/skeleton';
   import { initializeBranding } from '$lib/configuration';
+  import { settings } from '$lib/configuration';
+  import GoogleAnalytics from '$lib/components/tracking/GoogleAnalytics.svelte';
+  import GoogleConsents from '$lib/components/tracking/GoogleConsents.svelte';
+  import GoogleTagManger from '$lib/components/tracking/GoogleTagManger.svelte';
+  let googleTagManagerId = settings.google.tagManager;
+
   initializeStores();
   initializeBranding();
 </script>
 
 <main class="w-full h-full">
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe
+      title="googleTagManager"
+      src="https://www.googletagmanager.com/ns.html?id={googleTagManagerId}"
+      height="0"
+      width="0"
+      style="display:none;visibility:hidden"
+    ></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <slot />
+  <GoogleConsents />
 </main>
+<GoogleAnalytics />
+<GoogleTagManger />


### PR DESCRIPTION
Included interfaces and tracking components for Google Analytics and Tag Manager integration. Added configurations in `types.ts`, updated `package.json`, and implemented consent management in `GoogleConsents.svelte`.