### PR TITLE
Clear filter after loading it from session

### DIFF
--- a/src/routes/(authentication)/login/loading/+page.svelte
+++ b/src/routes/(authentication)/login/loading/+page.svelte
@@ -35,8 +35,11 @@
 
     let filtersJson = sessionStorage.getItem('filters');
     if (filtersJson) {
-      let storedFilters = JSON.parse(filtersJson || '{}');
+      let storedFilters = JSON.parse(filtersJson || '[]');
       filters.set(storedFilters);
+      // wait to delete from session storage, in case loading the filters in the line above triggers the session
+      // storage to be re-written
+      setTimeout(() => sessionStorage.setItem('filters', '[]'), 500);
     }
 
     goto(failed ? '/login/error' : redirectTo);


### PR DESCRIPTION
This prevents the death spiral when someone ends up with an invalid filter, which becomes impossible to remove