### PR TITLE
[ALS-7489] Add hyperlinks to analysis workspace examples

### DIFF
--- a/src/routes/(picsure)/(authorized)/analyze/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/analyze/+page.svelte
@@ -22,6 +22,7 @@
       personal access token. Copy your token and save as a text file called “token.txt” in the
       working directory of your chosen analysis workspace, such as <a
         href="https://platform.sb.biodatacatalyst.nhlbi.nih.gov/home"
+        target="_blank"
         title="BioData Catalyst Powered by Seven
       Bridges"
         class="anchor font-bold">BioData Catalyst Powered by Seven Bridges</a
@@ -29,6 +30,7 @@
       or
       <a
         href="https://terra.biodatacatalyst.nhlbi.nih.gov/#workspaces"
+        target="_blank"
         title="BioData Catalyst Powered by Terra"
         class="anchor font-bold">BioData Catalyst Powered by Terra</a
       >.

--- a/src/routes/(picsure)/(authorized)/analyze/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/analyze/+page.svelte
@@ -20,8 +20,18 @@
     <p>
       To connect to the PIC-SURE Application Programming Interface (API), you will need your
       personal access token. Copy your token and save as a text file called “token.txt” in the
-      working directory of your chosen analysis workspace, such as BioData Catalyst Powered by Seven
-      Bridges or BioData Catalyst Powered by Terra.
+      working directory of your chosen analysis workspace, such as <a
+        href="https://platform.sb.biodatacatalyst.nhlbi.nih.gov/home"
+        title="BioData Catalyst Powered by Seven
+      Bridges"
+        class="anchor font-bold">BioData Catalyst Powered by Seven Bridges</a
+      >
+      or
+      <a
+        href="https://terra.biodatacatalyst.nhlbi.nih.gov/#workspaces"
+        title="BioData Catalyst Powered by Terra"
+        class="anchor font-bold">BioData Catalyst Powered by Terra</a
+      >.
     </p>
     <div class="flex justify-center">
       <UserToken />


### PR DESCRIPTION
[ALS-7489] Updated the examples for analysis workspaces to include hyperlinks with descriptive titles for BioData Catalyst Powered by Seven Bridges and Terra. This improves user guidance and navigation for connecting to the PIC-SURE API.