### PR TITLE
[ALS-8645] [ALS-8644] Move table hander subscribers to stores

### DIFF
--- a/src/lib/components/datatable/DashboardDrawer.svelte
+++ b/src/lib/components/datatable/DashboardDrawer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getDrawerStore } from '@skeletonlabs/skeleton';
-  import { getDatasetDetails } from '$lib/services/dictionary';
+  import { getDatasetDetails } from '$lib/stores/Dictionary';
   import type { DashboardRow } from '$lib/stores/Dashboard';
   import { ProgressRadial } from '@skeletonlabs/skeleton';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';

--- a/src/lib/components/explorer/AddFilter.svelte
+++ b/src/lib/components/explorer/AddFilter.svelte
@@ -11,7 +11,7 @@
     createNumericFilter,
     createRequiredFilter,
   } from '$lib/models/Filter';
-  import { getConceptDetails } from '$lib/services/dictionary';
+  import { getConceptDetails } from '$lib/stores/Dictionary';
 
   const modalStore = getModalStore();
   const toastStore = getToastStore();

--- a/src/lib/components/explorer/Explorer.svelte
+++ b/src/lib/components/explorer/Explorer.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
-  import { DataHandler, type State } from '@vincjo/datatables/remote';
-  import { type Unsubscriber, writable } from 'svelte/store';
+  import { onMount } from 'svelte';
 
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
 
-  import type { Column } from '$lib/models/Tables';
-  import type { SearchResult } from '$lib/models/Search';
   import { branding, features } from '$lib/configuration';
-  import SearchStore from '$lib/stores/Search';
+  import type { Column } from '$lib/models/Tables';
+  import {
+    searchTerm,
+    selectedFacets,
+    tableHandler as handler,
+    error,
+    tour,
+    resetSearch,
+    loading as isLoading,
+  } from '$lib/stores/Search';
 
   import Actions from '$lib/components/explorer/cell/Actions.svelte';
   import SearchDatatable from '$lib/components/datatable/RemoteTable.svelte';
@@ -20,84 +25,39 @@
   /* eslint-disable @typescript-eslint/no-explicit-any */
   export let tourConfig: any;
 
-  const isLoading = writable(false);
-
-  let { searchTerm, search, selectedFacets, error } = SearchStore;
   let searchInput = $page.url.searchParams.get('search') || $searchTerm || '';
   const tableName = 'ExplorerTable';
-  $: tourEnabled = true;
-  $: isOpenAccess = $page.url.pathname.includes('/discover');
-
   const tableColumns = branding.explorePage.columns || [];
-
   const columns: Column[] = [
     ...tableColumns,
     { dataElement: 'id', label: 'Actions', class: 'w-36 text-center' },
   ];
-  const cellOverides = {
-    id: Actions,
-  };
+  const cellOverides = { id: Actions };
 
-  const handler = new DataHandler([] as SearchResult[], { rowsPerPage: 10 });
-  handler.onChange(async (state: State) => {
-    doDisableTour();
-    isLoading.set(true);
-    try {
-      return await search($searchTerm, $selectedFacets, state);
-    } catch (e) {
-      return [];
-    } finally {
-      isLoading.set(false);
-    }
-  });
+  $: isOpenAccess = $page.url.pathname.includes('/discover');
+  $: path = isOpenAccess ? '/discover' : '/explorer';
 
-  let unsubSelectedFacets: Unsubscriber;
-  let unsubSearchTerm: Unsubscriber;
-
-  onMount(() => {
-    unsubSelectedFacets = selectedFacets.subscribe(() => {
-      handler.setPage(1);
-      handler.invalidate();
-    });
-
-    unsubSearchTerm = searchTerm.subscribe(() => {
-      handler.setPage(1);
-      handler.invalidate();
-    });
-
-    if (searchInput) {
-      searchTerm.set(searchInput);
-    }
-  });
-
-  function doDisableTour() {
-    if (tourEnabled && (searchInput || ($selectedFacets && $selectedFacets.length > 0))) {
-      tourEnabled = false;
-    }
-  }
-
-  function updateSearch() {
-    if ($error) {
-      error.set('');
-      searchTerm.set('');
-    }
+  function update() {
+    if ($error) error.set('');
     searchTerm.set(searchInput);
-    const path = isOpenAccess ? '/discover' : '/explorer';
+
     goto(searchInput ? `${path}?search=${searchInput}` : `${path}`, { replaceState: true });
   }
 
-  function resetSearch() {
+  function reset() {
+    resetSearch();
     searchInput = '';
-    searchTerm.set('');
-    error.set('');
-    selectedFacets.set([]);
-    tourEnabled = true;
-    goto(isOpenAccess ? '/discover' : '/explorer');
+
+    goto(path);
   }
 
-  onDestroy(() => {
-    unsubSelectedFacets && unsubSelectedFacets();
-    unsubSearchTerm && unsubSearchTerm();
+  onMount(() => {
+    if (searchInput && searchInput !== $searchTerm) {
+      searchTerm.set(searchInput);
+    } else {
+      // reload table and facets
+      handler.invalidate();
+    }
   });
 </script>
 
@@ -108,7 +68,7 @@
   <div id="search-results-col" class="flex-auto">
     <div id="search-bar" class="flex gap-2 mb-6">
       <div class="flex-auto">
-        <Searchbox bind:searchTerm={searchInput} search={updateSearch} />
+        <Searchbox bind:searchTerm={searchInput} search={update} />
       </div>
       <div class="flex-none">
         {#if !isOpenAccess && (features.enableGENEQuery || features.enableSNPQuery)}
@@ -123,7 +83,7 @@
           class="btn variant-ghost-error hover:variant-filled-error"
           aria-label="You are on the reset button"
           disabled={!searchInput && $selectedFacets.length === 0}
-          on:click={resetSearch}
+          on:click={reset}
         >
           Reset
         </button>
@@ -136,7 +96,7 @@
     {:else if $searchTerm || $selectedFacets.length > 0}
       <SearchDatatable {tableName} {handler} {columns} {cellOverides} {isLoading} />
     {/if}
-    {#if features.explorer.enableTour && tourEnabled}
+    {#if features.explorer.enableTour && tour}
       <div id="explorer-tour" class="text-center mt-4">
         <ExplorerTour {tourConfig} />
       </div>

--- a/src/lib/components/explorer/Explorer.svelte
+++ b/src/lib/components/explorer/Explorer.svelte
@@ -96,7 +96,7 @@
     {:else if $searchTerm || $selectedFacets.length > 0}
       <SearchDatatable {tableName} {handler} {columns} {cellOverides} {isLoading} />
     {/if}
-    {#if features.explorer.enableTour && tour}
+    {#if features.explorer.enableTour && $tour}
       <div id="explorer-tour" class="text-center mt-4">
         <ExplorerTour {tourConfig} />
       </div>

--- a/src/lib/components/explorer/FacetCategory.svelte
+++ b/src/lib/components/explorer/FacetCategory.svelte
@@ -2,7 +2,7 @@
   import type { DictionaryFacetResult } from '$lib/models/api/DictionaryResponses';
   import { AccordionItem } from '@skeletonlabs/skeleton';
   import SearchStore from '$lib/stores/Search';
-  import { hiddenFacets } from '$lib/services/dictionary';
+  import { hiddenFacets } from '$lib/stores/Dictionary';
   import FacetItem from './FacetItem.svelte';
   import type { Facet } from '$lib/models/Search';
   let { updateFacets, selectedFacets } = SearchStore;

--- a/src/lib/components/explorer/FacetSideBar.svelte
+++ b/src/lib/components/explorer/FacetSideBar.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
   import { Accordion, ProgressRadial } from '@skeletonlabs/skeleton';
-  import SearchStore from '$lib/stores/Search';
-  import { updateFacetsFromSearch } from '$lib/services/dictionary';
-  import type { DictionaryFacetResult } from '$lib/models/api/DictionaryResponses';
-  import ErrorAlert from '../ErrorAlert.svelte';
-  import type { Facet } from '$lib/models/Search';
-  import FacetCategory from './FacetCategory.svelte';
-  import { onDestroy, onMount } from 'svelte';
-  import type { Unsubscriber } from 'svelte/store';
-  let { searchTerm, selectedFacets } = SearchStore;
 
-  let facetsPromise: Promise<DictionaryFacetResult[]>;
-  let unsubSearchTerm: Unsubscriber;
-  let unsubSelectedFacets: Unsubscriber;
+  import type { Facet } from '$lib/models/Search';
+  import type { DictionaryFacetResult } from '$lib/models/api/DictionaryResponses';
+  import { selectedFacets } from '$lib/stores/Search';
+  import { facetsPromise } from '$lib/stores/Dictionary';
+
+  import ErrorAlert from '../ErrorAlert.svelte';
+  import FacetCategory from './FacetCategory.svelte';
 
   function recreateFacetCategories(): DictionaryFacetResult[] {
     let facetsToShow: DictionaryFacetResult[] = [];
@@ -31,23 +26,9 @@
     });
     return facetsToShow;
   }
-
-  onMount(() => {
-    unsubSearchTerm = searchTerm.subscribe(() => {
-      facetsPromise = updateFacetsFromSearch($searchTerm, $selectedFacets);
-    });
-    unsubSelectedFacets = selectedFacets.subscribe(() => {
-      facetsPromise = updateFacetsFromSearch($searchTerm, $selectedFacets);
-    });
-  });
-
-  onDestroy(() => {
-    unsubSearchTerm && unsubSearchTerm();
-    unsubSelectedFacets && unsubSelectedFacets();
-  });
 </script>
 
-{#await facetsPromise}
+{#await $facetsPromise}
   <div class="radial-container">
     <ProgressRadial width="w-10" />
   </div>

--- a/src/lib/components/explorer/ResultInfoComponent.svelte
+++ b/src/lib/components/explorer/ResultInfoComponent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { SearchResult } from '$lib/models/Search';
-  import { getConceptDetails } from '$lib/services/dictionary';
+  import { getConceptDetails } from '$lib/stores/Dictionary';
   import { ProgressRadial } from '@skeletonlabs/skeleton';
 
   export let data: SearchResult;

--- a/src/lib/components/explorer/export/ExportStepper.svelte
+++ b/src/lib/components/explorer/export/ExportStepper.svelte
@@ -25,7 +25,7 @@
   import { getModalStore, type ModalSettings, getToastStore } from '@skeletonlabs/skeleton';
   import Confirmation from '$lib/components/modals/Confirmation.svelte';
   import { branding, features, settings, resources } from '$lib/configuration';
-  import { searchDictionary } from '$lib/services/dictionary';
+  import { searchDictionary } from '$lib/stores/Dictionary';
   import type { ExportInterface } from '$lib/models/Export';
   import { onMount } from 'svelte';
   export let query: QueryRequestInterface;

--- a/src/lib/components/tour/ExplorerTour.svelte
+++ b/src/lib/components/tour/ExplorerTour.svelte
@@ -7,7 +7,7 @@
   import 'driver.js/dist/driver.css';
   import '../../../tour.postcss';
 
-  import { searchTerm, selectedFacets, loading } from '$lib/stores/Search';
+  import { searchTerm, selectedFacets, searchPromise } from '$lib/stores/Search';
   import { clearFilters } from '$lib/stores/Filter';
   import { clearExports } from '$lib/stores/Export';
 
@@ -216,7 +216,7 @@
         searchBox.dispatchEvent(new Event('input'));
         searchBox.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
-        await $loading
+        await $searchPromise
           .then(() => {
             modalStore.close();
             tourDriver.drive();

--- a/src/lib/stores/Search.ts
+++ b/src/lib/stores/Search.ts
@@ -18,12 +18,12 @@ export const tableHandler: DataHandler<SearchResult> = new DataHandler([] as Sea
 export const tour: Writable<boolean> = writable(true);
 export const error: Writable<string> = writable('');
 
-selectedFacets.subscribe((data) => {
+selectedFacets.subscribe(() => {
   tableHandler.setPage(1);
   tableHandler.invalidate();
 });
 
-searchTerm.subscribe((data) => {
+searchTerm.subscribe(() => {
   tableHandler.setPage(1);
   tableHandler.invalidate();
 });

--- a/src/lib/stores/Search.ts
+++ b/src/lib/stores/Search.ts
@@ -1,26 +1,62 @@
 import { get, writable, type Writable } from 'svelte/store';
+import { DataHandler, type State } from '@vincjo/datatables/remote';
+
 import { type Facet, type SearchResult } from '$lib/models/Search';
 import type { DictionaryConceptResult } from '$lib/models/api/DictionaryResponses';
-import type { State } from '@vincjo/datatables/remote';
-import { searchDictionary } from '$lib/services/dictionary';
+import { searchDictionary } from '$lib/stores/Dictionary';
+import { updateFacetsFromSearch, facetsPromise } from '$lib/stores/Dictionary';
 
-export const loading: Writable<Promise<DictionaryConceptResult | undefined>> = writable(
+export const loading: Writable<boolean> = writable(false);
+export const searchPromise: Writable<Promise<DictionaryConceptResult | undefined>> = writable(
   Promise.resolve(undefined),
 );
 export const searchTerm: Writable<string> = writable('');
 export const selectedFacets: Writable<Facet[]> = writable([]);
+export const tableHandler: DataHandler<SearchResult> = new DataHandler([] as SearchResult[], {
+  rowsPerPage: 10,
+});
+export const tour: Writable<boolean> = writable(true);
 export const error: Writable<string> = writable('');
 
-async function search(searchTerm: string, facets: Facet[], state?: State): Promise<SearchResult[]> {
-  if (!searchTerm && (!facets || !facets.length)) {
+selectedFacets.subscribe((data) => {
+  tableHandler.setPage(1);
+  tableHandler.invalidate();
+});
+
+searchTerm.subscribe((data) => {
+  tableHandler.setPage(1);
+  tableHandler.invalidate();
+});
+
+tableHandler.onChange(async (state: State) => {
+  const term = get(searchTerm);
+  const facets = get(selectedFacets);
+  loading.set(true);
+  if (get(tour) && (term || facets.length > 0)) {
+    tour.set(false);
+  }
+  try {
+    facetsPromise.set(updateFacetsFromSearch());
+    return await search(state);
+  } catch (e) {
+    return [];
+  } finally {
+    loading.set(false);
+  }
+});
+
+export async function search(state?: State): Promise<SearchResult[]> {
+  const facets = get(selectedFacets);
+  const term = get(searchTerm);
+  if (!term && !facets.length) {
     state?.setTotalRows(0);
     return [];
   }
-  const search = searchDictionary(searchTerm.trim(), facets, {
+  const search = searchDictionary(term.trim(), facets, {
     pageNumber: state?.pageNumber ? state?.pageNumber - 1 : 0,
     pageSize: state?.rowsPerPage,
   });
-  loading.set(search);
+  searchPromise.set(search);
   const response = await search.catch((e) => {
     console.error(e);
     state?.setTotalRows(0);
@@ -29,6 +65,7 @@ async function search(searchTerm: string, facets: Facet[], state?: State): Promi
     );
     throw e;
   });
+
   if (!response) {
     error.set(
       'An error occurred while searching. If the problem persists, please contact an administrator.',
@@ -56,6 +93,7 @@ export function resetSearch() {
   searchTerm.set('');
   selectedFacets.set([]);
   error.set('');
+  tour.set(true);
 }
 
 export default {

--- a/src/lib/stores/Stats.ts
+++ b/src/lib/stores/Stats.ts
@@ -4,7 +4,7 @@ import * as api from '$lib/api';
 import type { LandingStat, StatField } from '$lib/types';
 import type { ExpectedResultType } from '$lib/models/query/Query';
 import { getBlankQueryRequest } from '$lib/QueryBuilder';
-import { getFacetCategoryCount, getConceptCount } from '$lib/services/dictionary';
+import { getFacetCategoryCount, getConceptCount } from '$lib/stores/Dictionary';
 import { isUserLoggedIn } from '$lib/stores/User';
 import { branding, features } from '$lib/configuration';
 

--- a/tests/routes/explorer/tour/test.ts
+++ b/tests/routes/explorer/tour/test.ts
@@ -14,6 +14,7 @@ test.use({ storageState: 'tests/.auth/generalUser.json' });
 test.beforeEach(async ({ page }) => {
   await mockApiSuccess(page, facetResultPath, facetsResponse);
   await mockApiSuccess(page, '*/**/picsure/proxy/dictionary-api/concepts*', detailResponseCat);
+  await mockApiSuccess(page, '*/**/picsure/query/sync', '9999');
 });
 
 test('Explorer tour button opens instruction modal', async ({ page }) => {


### PR DESCRIPTION
When the handler and subscribers were at the component layer, there could be instances where the handler onChange method is run on component mount. At that time, subscribers seem to be added using old terms or facets, then rerun again with the new term, causing multiple api requests with different return data. This manifests on the ui as delayed results for given search and sometimes no spinner when you would expect it.

Pulling the table handler outside of the component with this change initializes one central handler for the search table and adds store subscribers when the store is first accessed, typically on initial site loading. The search term and facets are saved at the store level like this, and so the subscribers for them will remain active throughout the current site session and only send search requests when either value actually changes.

- Move handler initialization to search store.
- Move/Rename dictionary service to store, since it functions more like a store with writable elements.
- Move and combine search term and facets subscriptions from Explorer and FacetSideBar components into search store.
- Remove unnecessary term and facet check for generating hidden (count = 0) facet items from sidebar.