### PR TITLE
[ALS-8208] PFB Configuration

### DIFF
--- a/src/lib/assets/configuration.json
+++ b/src/lib/assets/configuration.json
@@ -74,7 +74,8 @@
     "goTo": {
       "instructions": "Copy your personal access token and save as a text file called \"token.txt\" in the same working directory to execute the code above.",
       "links": []
-    }
+    },
+    "pfbExportUrls": []
   },
   "landing": {
     "searchPlaceholder": "Search terms or variables of interest…",

--- a/src/lib/components/explorer/export/ExportStepper.svelte
+++ b/src/lib/components/explorer/export/ExportStepper.svelte
@@ -35,9 +35,9 @@
   export let showTreeStep = false;
   export let rows: ExportRowInterface[] = [];
   export let activeType: ExpectedResultType;
-  
+
   // Auto select csv export when pfb feature is disabled.
-  if(!features.Explorer.enablePfbExport){
+  if (!features.Explorer.enablePfbExport) {
     query.query.expectedResultType === 'DATAFRAME';
     activeType = 'DATAFRAME';
   }
@@ -380,10 +380,10 @@
         console.error('Error in getSignedUrl', error);
       }
     }
-    if(!url) return;
+    if (!url) return;
     exportLoading = true;
     let signedUrl = await getSignedUrl();
-    if(signedUrl){
+    if (signedUrl) {
       window.open(url + encodeURIComponent(signedUrl));
     }
     exportLoading = false;

--- a/src/lib/components/explorer/export/ExportStepper.svelte
+++ b/src/lib/components/explorer/export/ExportStepper.svelte
@@ -12,7 +12,7 @@
 
   import type { ExportRowInterface } from '$lib/models/ExportRow';
   import type { QueryRequestInterface } from '$lib/models/api/Request';
-  import type { DatasetError } from '$lib/models/Dataset';
+  import type { DataSet } from '$lib/models/Dataset';
   import type { ExportInterface } from '$lib/models/Export';
   import { Query, type ExpectedResultType } from '$lib/models/query/Query.ts';
   import { state } from '$lib/stores/Stepper';
@@ -25,7 +25,6 @@
   import Step from '$lib/components/steppers/horizontal/Step.svelte';
   import Datatable from '$lib/components/datatable/Table.svelte';
   import UserToken from '$lib/components/UserToken.svelte';
-  import CopyButton from '$lib/components/buttons/CopyButton.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import CardButton from '$lib/components/buttons/CardButton.svelte';
   import Confirmation from '$lib/components/modals/Confirmation.svelte';
@@ -34,13 +33,6 @@
   export let query: QueryRequestInterface;
   export let showTreeStep = false;
   export let rows: ExportRowInterface[] = [];
-  export let activeType: ExpectedResultType;
-
-  // Auto select csv export when pfb feature is disabled.
-  if (!features.Explorer.enablePfbExport) {
-    query.query.expectedResultType === 'DATAFRAME';
-    activeType = 'DATAFRAME';
-  }
 
   interface DataSetResponse {
     picsureResultId?: string;
@@ -57,13 +49,14 @@
     { dataElement: 'type', label: 'Type', sort: true, class: 'text-center' },
   ];
 
-  let statusPromise: Promise<string>;
+  let activeType: ExpectedResultType;
+  let statusPromise: Promise<unknown>;
   let preparePromise: Promise<void>;
-  let datasetPromise: Promise<void | DataSetResponse>;
+  let datasetIdPromise: Promise<void | DataSetResponse>;
+  let saveDatasetPromise: Promise<DataSet>;
   let datasetNameInput: string = '';
   let picsureResultId: string = '';
   let lockDownload = true;
-  let error: string = '';
   let sampleIds = false;
   let lastExports: ExportRowInterface[] = [];
   let loadingSampleIds = false;
@@ -72,8 +65,13 @@
 
   $: datasetId = '';
   $: processingMessage = '';
-  $: apiExport = false;
   $: exportLoading = false;
+
+  // Auto select csv export when pfb feature is disabled.
+  if (!features.explorer.enablePfbExport) {
+    query.query.expectedResultType === 'DATAFRAME';
+    activeType = 'DATAFRAME';
+  }
 
   onMount(async () => {
     const exportedSampleIds = $exports.filter((e: ExportInterface) =>
@@ -158,38 +156,23 @@
     }
   }
 
-  function onNextHandler(e: CustomEvent): void {
-    if (e.detail.step === 0 && !showTreeStep) {
-      // nothing needs to be done here
-      return;
-    }
-    if (e.detail.step === 1 && showTreeStep) {
-      //TODO: Load tree
-    } else if ((e.detail.step === 1 && !showTreeStep) || (showTreeStep && e.detail.step === 2)) {
+  async function onNextHandler(e: CustomEvent): Promise<void> {
+    const lastStepName = $state.stepMap[$state.current - 1] || '';
+    const stepName = e.detail.name;
+
+    // nothing needs to be on review step
+    if (stepName === 'review') return;
+
+    if (lastStepName === 'review') {
       preparePromise = submitQuery();
-    } else if ((e.detail.step === 2 && !showTreeStep) || (showTreeStep && e.detail.step === 3)) {
-      createNamedDataset();
     }
-    if (e.detail.state.total - 1 === e.detail.step + 1) {
-      statusPromise = new Promise((resolve, reject) => {
-        const interval = setInterval(async () => {
-          const status = await checkExportStatus(picsureResultId);
-          if (status === 'ERROR') {
-            lockDownload = true;
-            clearInterval(interval);
-            reject(status);
-          } else if (!['PENDING', 'RUNNING', 'QUEUED'].includes(status)) {
-            lockDownload = false;
-            clearInterval(interval);
-            resolve(status);
-          }
-        }, 2000);
+
+    if (stepName === 'start') {
+      saveDatasetPromise = createDatasetName(datasetId, datasetNameInput).then((data: DataSet) => {
+        statusPromise = checkExportStatus(picsureResultId);
+        return data;
       });
     }
-  }
-
-  function onBackHandler(): void {
-    error = '';
   }
 
   async function submitQuery(): Promise<void> {
@@ -207,7 +190,7 @@
           processingMessage = statetext.waiting;
         }, PROMISE_WAIT_INTERVAL * 1000);
       }
-      datasetPromise = method()
+      datasetIdPromise = method()
         .finally(() => clearInterval(interval))
         .catch((err) => {
           if (retry) {
@@ -226,7 +209,7 @@
           datasetId = res.picsureResultId || 'Error';
         }),
       );
-      await datasetPromise;
+      await datasetIdPromise;
     } catch (error) {
       $state.current--;
       console.error('Error in submitQuery', error);
@@ -234,32 +217,18 @@
     }
   }
 
-  async function createNamedDataset() {
-    try {
-      await createDatasetName(datasetId, datasetNameInput);
-    } catch (err) {
-      if (err instanceof Object) {
-        const errObj = err as DatasetError;
-        error = errObj?.message?.message || 'Error Creating Named Dataset';
-      } else {
-        error = String(err) || 'Error Creating Named Dataset';
-      }
-      $state.current--;
-      console.error('Error in createNamedDataset', err);
-    }
-  }
-
-  async function checkExportStatus(lastPicsureResultId?: string) {
-    let statusId = lastPicsureResultId ? lastPicsureResultId : datasetId;
-    const path = 'picsure/query/' + statusId + '/status';
-    try {
-      const res = await api.post(path, query);
-      picsureResultId = res.picsureResultId;
-      return res.status;
-    } catch (error) {
-      console.error('Error in checkExportStatus', error); //TODO handle errors
-    }
-    return 'ERROR';
+  function checkExportStatus(lastPicsureResultId?: string) {
+    const statusId = lastPicsureResultId || datasetId;
+    return api
+      .post('picsure/query/' + statusId + '/status', query)
+      .then((res: { picsureResultId: string; status: string }) => {
+        if (res.status === 'ERROR') {
+          lockDownload = true;
+          return Promise.reject(res.status);
+        }
+        picsureResultId = res.picsureResultId;
+        lockDownload = false;
+      });
   }
 
   function selectExportType(exportType: ExpectedResultType) {
@@ -394,10 +363,9 @@
   class="w-full h-full m-8"
   on:complete={onComplete}
   on:next={onNextHandler}
-  on:back={onBackHandler}
   buttonCompleteLabel="Done"
 >
-  <Step locked={dataLimitExceeded()}>
+  <Step name="review" locked={dataLimitExceeded()}>
     <svelte:fragment slot="header">Review Cohort Details:</svelte:fragment>
     <div id="first-step-container" class="flex flex-col w-full h-full items-center">
       <Summary />
@@ -465,7 +433,7 @@
     </div>
   </Step>
   {#if showTreeStep}
-    <Step>
+    <Step name="select-variables">
       <svelte:fragment slot="header">Finalize Data:</svelte:fragment>
       <section class="flex flex-col w-full h-full items-center">
         <Summary />
@@ -480,8 +448,8 @@
       </section>
     </Step>
   {/if}
-  {#if features.Explorer.enablePfbExport}
-    <Step locked={activeType === undefined}>
+  {#if features.explorer.enablePfbExport}
+    <Step name="select-type" locked={activeType === undefined}>
       <svelte:fragment slot="header">Review and Save Dataset:</svelte:fragment>
       <section class="flex flex-col w-full h-full items-center">
         <Summary />
@@ -508,7 +476,7 @@
       </section>
     </Step>
   {/if}
-  <Step locked={!datasetNameInput || datasetNameInput.length < 2 || !datasetId}>
+  <Step name="save-dataset" locked={!datasetNameInput || datasetNameInput.length < 2 || !datasetId}>
     <svelte:fragment slot="header">Save Dataset ID:</svelte:fragment>
     <section class="flex flex-col w-full h-full items-center">
       <Summary />
@@ -519,13 +487,6 @@
           your Dataset IDs.
         </header>
         <hr />
-        {#if error}
-          <div class="w-full h-full m-2">
-            <ErrorAlert title="Error">
-              {error}
-            </ErrorAlert>
-          </div>
-        {/if}
         <div class="card-body p-4 flex flex-col justify-center items-center">
           <div>
             <div class="flex items-center m-2">
@@ -542,7 +503,7 @@
             <div class="flex items-center m-2">
               <div class="flex items-center">
                 <label for="dataset-id" class="font-bold mr-2">Dataset ID:</label>
-                {#await datasetPromise}
+                {#await datasetIdPromise}
                   <ProgressRadial width="w-4" />
                   <div>{processingMessage}</div>
                 {:then}
@@ -557,11 +518,16 @@
       </div>
     </section>
   </Step>
-  <Step locked={lockDownload}>
+  <Step name="start" locked={lockDownload}>
     <svelte:fragment slot="header">Start Analysis:</svelte:fragment>
     <section class="flex flex-col w-full h-full items-center">
-      <div class="flex justify-center">
-        {#if features.explorer.allowDownload}
+      {#await saveDatasetPromise}
+        <div class="flex justify-center items-center">
+          <ProgressRadial width="w-4" />
+          <div>Saving your dataset...</div>
+        </div>
+      {:then}
+        <div class="flex justify-center">
           {#await statusPromise}
             <div class="flex justify-center items-center">
               <ProgressRadial width="w-4" />
@@ -574,7 +540,9 @@
                 <TabGroup class="card p-4">
                   <Tab bind:group={tabSet} name="python" value={0}>Python</Tab>
                   <Tab bind:group={tabSet} name="r" value={1}>R</Tab>
-                  <Tab bind:group={tabSet} name="download" value={2}>Download</Tab>
+                  {#if features.explorer.allowDownload}
+                    <Tab bind:group={tabSet} name="download" value={2}>Download</Tab>
+                  {/if}
                   <svelte:fragment slot="panel">
                     {#if tabSet === 0}
                       <CodeBlock
@@ -596,7 +564,7 @@
                           datasetId,
                         ) || 'Code not set'}
                       />
-                    {:else if tabSet === 2}
+                    {:else if features.explorer.allowDownload && tabSet === 2}
                       <button
                         class="btn variant-filled-primary"
                         on:click={() =>
@@ -653,28 +621,15 @@
               <div class="hidden">{e}</div>
             </div>
           {/await}
-        {/if}
-      </div>
-      {#if apiExport}
-        <div class="flex flex-col justify-center items-center">
-          <div class="flex justify-center">
-            Use your personal access token and the dataset ID to export your participant-level
-            cohort data using the PIC-SURE API.
-          </div>
-          <UserToken />
-          <div class="flex items-center m-4">
-            <div class="flex items-center">
-              <label for="dataset-id" class="font-bold ml-4 mr-2">Dataset ID:</label>
-              <div id="dataset-id" class="mr-4">{datasetId}</div>
-              <CopyButton itemToCopy={datasetId} />
-            </div>
-          </div>
-          <p>
-            Navigate to the <a class="anchor" href="/api">API page</a> to view examples and learn more
-            about the PIC-SURE API.
-          </p>
         </div>
-      {/if}
+      {:catch}
+        <div class="flex justify-center">
+          <ErrorAlert
+            title="An error occurred while saving your dataset. Please try again. If this problem persists, please
+            contact an administrator."
+          />
+        </div>
+      {/await}
     </section>
   </Step>
 </Stepper>

--- a/src/lib/components/steppers/horizontal/Step.svelte
+++ b/src/lib/components/steppers/horizontal/Step.svelte
@@ -3,12 +3,14 @@
   import { fade } from 'svelte/transition';
   import type { Writable } from 'svelte/store';
 
+  import type { StepperState } from '$lib/models/Stepper';
   import AngleButton from '$lib/components/buttons/AngleButton.svelte';
 
+  export let name: string;
   export let locked = false;
   export let buttonCompleteLabel: string = getContext('buttonCompleteLabel');
 
-  export let state: Writable<{ current: number; total: number }> = getContext('state');
+  export let state: Writable<StepperState> = getContext('state');
 
   export let onNext: (locked: boolean) => void = getContext('onNext');
   export let onBack: () => void = getContext('onBack');
@@ -16,10 +18,12 @@
 
   // Register step on init (keep these paired)
   const stepIndex = $state.total;
+  $state.stepMap = [...$state.stepMap, name];
   $state.total++;
 
   onDestroy(() => {
     $state.total--;
+    $state.stepMap = $state.stepMap.filter((item) => item !== name);
   });
 </script>
 

--- a/src/lib/components/steppers/horizontal/Stepper.svelte
+++ b/src/lib/components/steppers/horizontal/Stepper.svelte
@@ -16,17 +16,19 @@
     await new Promise((resolve) => setTimeout(resolve));
 
     if (locked) return;
-    dispatch('next', { step: $state.current, state: $state });
-    $state.current++;
+    const newStep = $state.current + 1;
+    dispatch('next', { step: $state.current, name: $state.stepMap[newStep], state: $state });
+    $state.current = newStep;
   }
   function onBack() {
-    dispatch('back', { step: $state.current, state: $state });
-    $state.current = $state.current === 1 ? 0 : $state.current - 1;
+    const newStep = $state.current === 1 ? 0 : $state.current - 1;
+    dispatch('back', { step: $state.current, name: $state.stepMap[newStep], state: $state });
+    $state.current = newStep;
   }
   function onComplete(stepIndex: number, locked: boolean) {
     if (locked) return;
 
-    dispatch('complete', { step: stepIndex, state: $state });
+    dispatch('complete', { step: stepIndex, name: $state.stepMap[stepIndex], state: $state });
   }
   setContext('onBack', onBack);
   setContext('onNext', onNext);
@@ -48,6 +50,7 @@
           class:flex-1={isActive(step)}
         >
           <span
+            data-testid="step-{$state.stepMap[step]}"
             class="badge text-sm {isActive(step)
               ? 'variant-filled-primary'
               : 'variant-filled-surface'}">{isActive(step) ? `Step ${step + 1}` : step + 1}</span

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -105,16 +105,15 @@ export const routes: Route[] = [
 export const features: Indexable = {
   explorer: {
     allowExport: import.meta.env?.VITE_ALLOW_EXPORT === 'true',
-    allowDownload: import.meta.env?.VITE_ALLOW_DOWNLOAD !== 'false',
+    allowDownload: import.meta.env?.VITE_ALLOW_DOWNLOAD !== 'false', // default true
     exportsEnableExport: import.meta.env?.VITE_ALLOW_EXPORT_ENABLED === 'true',
-    exportResultType: (import.meta.env?.VITE_EXPORT_RESULT_TYPE ||
-      'DATAFRAME') as ExpectedResultType,
+    exportResultType: (import.meta.env?.VITE_EXPORT_RESULT_TYPE || 'DATAFRAME') as ExpectedResultType,
     variantExplorer: import.meta.env?.VITE_VARIANT_EXPLORER === 'true',
     distributionExplorer: import.meta.env?.VITE_DIST_EXPLORER === 'true',
     enableTour: import.meta.env?.EXPLORER_TOUR ? import.meta.env?.EXPLORE_TOUR === 'true' : true, // default to true unless set otherwise
     authTour: import.meta.env?.VITE_AUTH_TOUR_NAME ?? 'NHANES-Auth',
     enableHierarchy: import.meta.env?.VITE_ENABLE_HIERARCHY === 'true',
-    enableTerraExport: import.meta.env?.VITE_ENABLE_TERRA_EXPORT === 'true',
+    enablePfbExport: import.meta.env?.VITE_DOWNLOAD_AS_PFB !== 'false', // default true
     enableSampleIdCheckbox: import.meta.env?.VITE_ENABLE_SAMPLE_ID_CHECKBOX === 'true',
   },
   login: {
@@ -127,7 +126,7 @@ export const features: Indexable = {
   useQueryTemplate: import.meta.env?.VITE_USE_QUERY_TEMPLATE === 'true',
   discover: import.meta.env?.VITE_DISCOVER === 'true',
   discoverFeautures: {
-    enableTour: import.meta.env?.EXPLORER_TOUR !== 'false',
+    enableTour: import.meta.env?.EXPLORER_TOUR !== 'false', // default true
     openTour: import.meta.env?.VITE_OPEN_TOUR_NAME ?? 'BDC-Open',
     distributionExplorer: import.meta.env?.VITE_DIST_EXPLORER === 'true',
   },

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -107,7 +107,8 @@ export const features: Indexable = {
     allowExport: import.meta.env?.VITE_ALLOW_EXPORT === 'true',
     allowDownload: import.meta.env?.VITE_ALLOW_DOWNLOAD !== 'false', // default true
     exportsEnableExport: import.meta.env?.VITE_ALLOW_EXPORT_ENABLED === 'true',
-    exportResultType: (import.meta.env?.VITE_EXPORT_RESULT_TYPE || 'DATAFRAME') as ExpectedResultType,
+    exportResultType: (import.meta.env?.VITE_EXPORT_RESULT_TYPE ||
+      'DATAFRAME') as ExpectedResultType,
     variantExplorer: import.meta.env?.VITE_VARIANT_EXPLORER === 'true',
     distributionExplorer: import.meta.env?.VITE_DIST_EXPLORER === 'true',
     enableTour: import.meta.env?.EXPLORER_TOUR ? import.meta.env?.EXPLORE_TOUR === 'true' : true, // default to true unless set otherwise

--- a/src/lib/models/Stepper.ts
+++ b/src/lib/models/Stepper.ts
@@ -3,13 +3,22 @@ import type { EventDispatcher } from 'svelte';
 export interface StepperState {
   current: number;
   total: number;
+  stepMap: string[];
+}
+
+interface StepAction {
+  step: number;
+  name: string;
+  state: StepperState;
 }
 
 export type StepperButton = 'submit' | 'reset' | 'button';
+
 export type StepperEvent = {
-  next: { step: number; state: StepperState };
-  step: { step: number; state: StepperState };
-  back: { step: number; state: StepperState };
-  complete: { step: number; state: StepperState };
+  next: StepAction;
+  step: StepAction;
+  back: StepAction;
+  complete: StepAction;
 };
+
 export type StepperEventDispatcher = EventDispatcher<StepperEvent>;

--- a/src/lib/stores/Stepper.ts
+++ b/src/lib/stores/Stepper.ts
@@ -1,4 +1,4 @@
 import type { StepperState } from '$lib/models/Stepper';
 import { writable, type Writable } from 'svelte/store';
 
-export const state: Writable<StepperState> = writable({ current: 0, total: 0 });
+export const state: Writable<StepperState> = writable({ current: 0, total: 0, stepMap: [] });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface ExplorePageConfig {
     instructions: string;
     links: Array<Link>;
   };
+  pfbExportUrls?: Link[];
 }
 
 export interface LandingStat {

--- a/src/routes/(picsure)/(authorized)/explorer/export/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/explorer/export/+page.svelte
@@ -109,7 +109,7 @@
       exportRows.push(parentStudyRow);
     }
   }
-  state.set({ current: 0, total: 0 });
+  state.set({ ...$state, current: 0, total: 0 });
 </script>
 
 <Content


### PR DESCRIPTION
**Note:** The export feature does not have unit/component/integration tests. Because it would be a bit out of scope, I am not implementing them at this time. However, because of the extensive code I am deploying to various environments in order to do a full regression test of the features after refactor.

Refactor of the Stepper component was required because when we disable the PFB button, it is odd to ask the user to select CSV button (which is the only button at that point) to proceed. Removing the export type selection step reduces the total number of steps breaking the onNextHandler actions which index api functionality based on the step indexes. Refactoring to use names instead makes the code read a little cleaner but also resolves the issue.

- Refactor ExportStepper to use more promises to dynamically return errors and content.
- Add step names to stepper component for cleaner onNextHandler.
- Configure PFB, Seven Bridges, and Terra buttons.