### PR TITLE
Add beforeNavigate to clean up subscriptions

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -13,16 +13,22 @@ async function send({
   path,
   data,
   headers,
+  signal,
 }: {
   method: string;
   path: string;
   data?: any; //TODO: Change this
   headers?: any;
+  signal?: AbortSignal;
 }) {
-  const opts: { method: string; headers: { [key: string]: string }; body?: string } = {
+  const opts: { method: string; headers: { [key: string]: string }; body?: string; signal?: AbortSignal } = {
     method,
     headers: {},
   };
+
+  if (signal) {
+    opts.signal = signal;
+  }
 
   if (data) {
     opts.headers['Content-Type'] = 'application/json';
@@ -49,20 +55,20 @@ async function send({
   return await handleResponse(res);
 }
 
-export function get(path: string, headers?: any) {
-  return send({ method: 'GET', path, headers });
+export function get(path: string, headers?: any, signal?: AbortSignal) {
+  return send({ method: 'GET', path, headers, signal });
 }
 
-export function del(path: string, headers?: any) {
-  return send({ method: 'DELETE', path, headers });
+export function del(path: string, headers?: any, signal?: AbortSignal) {
+  return send({ method: 'DELETE', path, headers, signal });
 }
 
-export function post(path: string, data: any, headers?: any) {
-  return send({ method: 'POST', path, data, headers });
+export function post(path: string, data: any, headers?: any, signal?: AbortSignal) {
+  return send({ method: 'POST', path, data, headers, signal });
 }
 
-export function put(path: string, data: any, headers?: any) {
-  return send({ method: 'PUT', path, data, headers });
+export function put(path: string, data: any, headers?: any, signal?: AbortSignal) {
+  return send({ method: 'PUT', path, data, headers, signal });
 }
 
 async function handleResponse(res: Response) {

--- a/src/lib/components/explorer/results/ResultsPanel.svelte
+++ b/src/lib/components/explorer/results/ResultsPanel.svelte
@@ -119,7 +119,9 @@
     (showExplorerDistributions || showDiscoverDistributions || showVariantExplorer);
 
   onMount(async () => {
-    triggerRefreshCount = getCount();
+    unsubFilters = filters.subscribe(() => {
+      triggerRefreshCount = getCount();
+    });
   });
 
   afterNavigate(async () => {

--- a/src/lib/components/explorer/results/ResultsPanel.svelte
+++ b/src/lib/components/explorer/results/ResultsPanel.svelte
@@ -12,7 +12,7 @@
   import { ProgressRadial, getModalStore, getToastStore } from '@skeletonlabs/skeleton';
   import { elasticInOut } from 'svelte/easing';
   import { onDestroy, onMount } from 'svelte';
-  import { afterNavigate, goto } from '$app/navigation';
+  import { afterNavigate, beforeNavigate, goto } from '$app/navigation';
   import type { Unsubscriber } from 'svelte/store';
   import { getQueryRequest } from '$lib/QueryBuilder';
   import { loadAllConcepts } from '$lib/services/hpds';
@@ -119,17 +119,21 @@
     (showExplorerDistributions || showDiscoverDistributions || showVariantExplorer);
 
   onMount(async () => {
-    unsubFilters = filters.subscribe(() => {
-      triggerRefreshCount = getCount();
-    });
+    triggerRefreshCount = getCount();
   });
 
   afterNavigate(async () => {
     isOpenAccess = $page.url.pathname.includes('/discover');
     const isExplorer = $page.url.pathname.includes('/explorer');
     if (isExplorer || isOpenAccess) {
-      triggerRefreshCount = getCount();
+      unsubFilters = filters.subscribe(() => {
+        triggerRefreshCount = getCount();
+      });
     }
+  });
+
+  beforeNavigate(() => {
+    unsubFilters && unsubFilters();
   });
 
   onDestroy(() => {

--- a/src/routes/(picsure)/+layout.svelte
+++ b/src/routes/(picsure)/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import {
     AppShell,
     Modal,
@@ -81,12 +81,13 @@
           message:
             'Your selected filters contain stigmatizing variables and/or genomic filters, which are not supported with Discover',
           backTo: 'Explore',
-          resetQuery: () => {
-            panelOpen.set(false);
-            removeGenomicFilters();
-            removeUnallowedFilters();
-            goto(`/discover`);
-          },
+            resetQuery: async () => {
+                panelOpen.set(false);
+                await tick();
+                removeGenomicFilters();
+                removeUnallowedFilters();
+                await goto(`/discover`);
+            },
         };
       }
       if (notAuthorized) {
@@ -94,10 +95,11 @@
           message:
             'You are not authorized to access the data in Explore based on your selected filters.',
           backTo: 'Discover',
-          resetQuery: () => {
+          resetQuery: async () => {
             panelOpen.set(false);
+            await tick();
             removeInvalidFilters();
-            goto(`/explorer`);
+            await goto(`/explorer`);
           },
         };
       }

--- a/src/routes/(picsure)/+layout.svelte
+++ b/src/routes/(picsure)/+layout.svelte
@@ -85,14 +85,7 @@
             panelOpen.set(false);
             removeGenomicFilters();
             removeUnallowedFilters();
-            // Use requestAnimationFrame to ensure filter changes are fully processed
-            // This gives more time for subscriptions to complete their work
-            requestAnimationFrame(() => {
-              // Add another requestAnimationFrame to ensure we're in a stable state
-              requestAnimationFrame(() => {
-                goto(`/discover`);
-              });
-            });
+            goto(`/discover`);
           },
         };
       }
@@ -104,14 +97,7 @@
           resetQuery: async () => {
             panelOpen.set(false);
             removeInvalidFilters();
-            // Use requestAnimationFrame to ensure filter changes are fully processed
-            // This gives more time for subscriptions to complete their work
-            requestAnimationFrame(() => {
-              // Add another requestAnimationFrame to ensure we're in a stable state
-              requestAnimationFrame(() => {
-                goto(`/explorer`);
-              });
-            });
+            goto(`/explorer`);
           },
         };
       }

--- a/tests/routes/explorer/results-panel/test.ts
+++ b/tests/routes/explorer/results-panel/test.ts
@@ -60,9 +60,9 @@ test.describe('Results Panel', () => {
       `${conceptsDetailPath}${detailResponseCat.dataset}`,
       detailResponseCat,
     );
-    await mockApiFail(page, countResultPath, 'failed');
     await page.locator('#row-0 button[title=Filter]').click();
     await page.locator('#options-container label:nth-child(1)').click();
+    await mockApiFail(page, countResultPath, 'failed');
     await page.getByTestId('add-filter').click();
 
     // Then


### PR DESCRIPTION
This pull request updates the `ResultsPanel.svelte` component to improve navigation handling and resource cleanup. The most important changes include adding a new `beforeNavigate` handler to unsubscribe from filters before navigation and restructuring the subscription logic to ensure it only applies to relevant routes.

### Navigation handling improvements:
* Added `beforeNavigate` from `$app/navigation` to handle unsubscription of `filters` before navigating to a new page, ensuring proper cleanup of resources. [[1]](diffhunk://#diff-cddcf1b04ad09859e6edad24ab8225c6534083eb7f490c90c2b0977db33d366dL15-R15) [[2]](diffhunk://#diff-cddcf1b04ad09859e6edad24ab8225c6534083eb7f490c90c2b0977db33d366dL122-R138)

### Subscription logic restructuring:
* Moved the `filters.subscribe` logic from `onMount` to `afterNavigate`, ensuring the subscription is set up only for specific routes (`/explorer` or `/discover`).