### PR TITLE
[ALS-8742] Adding DCC harmonized variable to export causes errors

### DIFF
--- a/src/lib/QueryBuilder.ts
+++ b/src/lib/QueryBuilder.ts
@@ -4,7 +4,9 @@ import type { QueryRequestInterface } from '$lib/models/api/Request';
 import { get } from 'svelte/store';
 import { user } from '$lib/stores/User';
 import { filters, hasGenomicFilter } from '$lib/stores/Filter';
+import { exports } from '$lib/stores/Export';
 import type { Filter } from '$lib/models/Filter';
+import type { ExportInterface } from '$lib/models/Export.ts';
 
 const harmonizedPath = '\\DCC Harmonized data set';
 const harmonizedConsentPath = '\\_harmonized_consent\\';
@@ -40,6 +42,12 @@ export function getQueryRequest(
       });
     } else if (filter.filterType === 'snp') {
       query.addSnpFilter(filter.snpValues);
+    }
+  });
+
+  (get(exports) as ExportInterface[]).forEach((exportedField) => {
+    if (exportedField.conceptPath) {
+      query.addField(exportedField.conceptPath);
     }
   });
 

--- a/src/lib/models/query/Query.ts
+++ b/src/lib/models/query/Query.ts
@@ -106,6 +106,10 @@ export class Query implements QueryInterface {
     this.requiredFields.push(field);
   }
 
+  addField(field: string) {
+    this.fields.push(field);
+  }
+
   addAnyRecordOf(field: string) {
     this.anyRecordOf.push(field);
   }


### PR DESCRIPTION
This pull request enhances the functionality of the query-building system by introducing support for exporting additional fields into the query. The most important changes include adding a new method to the `Query` class, updating the `getQueryRequest` function to include exported fields, and importing the necessary types and stores.

### Enhancements to query-building functionality:

* **New method in `Query` class**: Added the `addField` method to the `Query` class, allowing fields to be dynamically added to a query. (`src/lib/models/query/Query.ts`, [src/lib/models/query/Query.tsR109-R112](diffhunk://#diff-7b6ad03bf2b4e510ed24e1c808359193767944273a1e86341156567ccdee77a3R109-R112))
* **Exported fields inclusion**: Updated the `getQueryRequest` function to include fields from the `exports` store into the query using the new `addField` method. (`src/lib/QueryBuilder.ts`, [src/lib/QueryBuilder.tsR48-R53](diffhunk://#diff-922bb8f90b1b0816f078d7c41a55af203218716b0d20b4efcca6d55132eb8cbaR48-R53))

### Supporting changes:

* **Imports for exports functionality**: Added imports for the `exports` store and the `ExportInterface` type to support the new functionality. (`src/lib/QueryBuilder.ts`, [src/lib/QueryBuilder.tsR7-R9](diffhunk://#diff-922bb8f90b1b0816f078d7c41a55af203218716b0d20b4efcca6d55132eb8cbaR7-R9))