### PR TITLE
[ALS-8297] Move loadResources

### DIFF
--- a/src/lib/stores/ResultStore.ts
+++ b/src/lib/stores/ResultStore.ts
@@ -8,7 +8,7 @@ import { countResult } from '$lib/utilities/PatientCount';
 import type { StatResult, StatValue } from '$lib/models/Stat';
 import { filters } from '$lib/stores/Filter';
 import { searchTerm, selectedFacets } from '$lib/stores/Search';
-import { loading as resourcesPromise } from '$lib/stores/Resources';
+import { loading as resourcesPromise, loadResources } from '$lib/stores/Resources';
 
 const CACHE_MAX_ENTRIES = 100;
 const requestCache: Map<string, StatResult[]> = new Map();
@@ -18,6 +18,7 @@ export const loading: Writable<Promise<void>> = writable(Promise.resolve());
 export const totalParticipants: Writable<number> = writable(0);
 
 export async function loadPatientCount(isOpenAccess: boolean) {
+  loadResources();
   try {
     if (requestCache.size >= CACHE_MAX_ENTRIES) {
       requestCache.clear();

--- a/src/lib/stores/Stats.ts
+++ b/src/lib/stores/Stats.ts
@@ -5,7 +5,7 @@ import { branding } from '$lib/configuration';
 import { getValidStatList, populateStatRequests, StatPromise } from '$lib/utilities/StatBuilder';
 
 import type { StatResult } from '$lib/models/Stat';
-import { loading as resourcesPromise } from '$lib/stores/Resources';
+import { loading as resourcesPromise, loadResources } from '$lib/stores/Resources';
 
 export const hasError: Writable<boolean> = writable(false);
 export const loaded: Writable<boolean> = writable(false);
@@ -19,6 +19,7 @@ export const authStats: Readable<StatResult[]> = derived(statData, ($s) =>
 let lastStatRequest: string = '';
 
 export async function loadLandingStats() {
+  loadResources();
   try {
     const validStats = getValidStatList(branding?.landing?.stats || []);
 

--- a/src/routes/(picsure)/+layout.svelte
+++ b/src/routes/(picsure)/+layout.svelte
@@ -20,14 +20,12 @@
   import Drawer from '$lib/components/Drawer.svelte';
   import DashboardDrawer from '$lib/components/dashboard/DashboardDrawer.svelte';
   import FilterWarning from '$lib/components/explorer/FilterWarning.svelte';
-  import { loadResources } from '$lib/stores/Resources';
 
   let { children }: { children?: Snippet } = $props();
   let filterWarningModal: boolean = $state(false);
 
   onMount(() => {
     document.body.classList.add('started');
-    loadResources();
   });
 
   let showSidebar = $derived(

--- a/src/routes/(picsure)/+layout.svelte
+++ b/src/routes/(picsure)/+layout.svelte
@@ -20,12 +20,14 @@
   import Drawer from '$lib/components/Drawer.svelte';
   import DashboardDrawer from '$lib/components/dashboard/DashboardDrawer.svelte';
   import FilterWarning from '$lib/components/explorer/FilterWarning.svelte';
+  import { loadResources } from '$lib/stores/Resources';
 
   let { children }: { children?: Snippet } = $props();
   let filterWarningModal: boolean = $state(false);
 
   onMount(() => {
     document.body.classList.add('started');
+    loadResources();
   });
 
   let showSidebar = $derived(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,13 +3,11 @@
   import '@fortawesome/fontawesome-free/css/all.min.css';
   import '../styles/app.css';
   import { initializeBranding } from '$lib/configuration';
-  import { loadResources } from '$lib/stores/Resources';
   import GoogleTracking from '$lib/components/tracking/GoogleTracking.svelte';
 
   let { children }: { children?: Snippet } = $props();
 
   initializeBranding();
-  loadResources();
 </script>
 
 <main class="w-full h-full">


### PR DESCRIPTION
The loadResources method can't be in the higher layout because the user doesn't have a token yet for the resources api call that happens when the federated feature flag is on. This causes the application to not allow login. Moving it to before the calls for stats and results fixes this issue because they only load on pages that a logged in user accesses.