### PR TITLE
[ALS-8136] Add uuid to result store caching to allow filter edit changes

### DIFF
--- a/src/lib/stores/Filter.ts
+++ b/src/lib/stores/Filter.ts
@@ -47,9 +47,14 @@ filters.subscribe((f) => {
 
 function restoreFilters() {
   if (browser && sessionStorage.getItem('filters')) {
-    return JSON.parse(sessionStorage.getItem('filters') || '[]');
+    const oldFilters: Filter[] = JSON.parse(sessionStorage.getItem('filters') || '[]');
+    return oldFilters.map((filter) => ({ ...filter, uuid: filterUUID(filter) }));
   }
   return [];
+}
+
+function filterUUID(filter: Filter) {
+  return uuid.v5(JSON.stringify({ ...filter, uuid: undefined }), SESSION_NAMESPACE);
 }
 
 export function addFilter(filter: Filter) {
@@ -59,7 +64,7 @@ export function addFilter(filter: Filter) {
       currentFilters.splice(currentFilters.indexOf(f), 1);
     }
   });
-  filter.uuid = uuid.v5(JSON.stringify({ ...filter, uuid: undefined }), SESSION_NAMESPACE);
+  filter.uuid = filterUUID(filter);
   filters.set([...currentFilters, filter]);
   return filter;
 }

--- a/src/lib/stores/Filter.ts
+++ b/src/lib/stores/Filter.ts
@@ -1,9 +1,12 @@
 import { get, derived, writable, type Readable, type Writable } from 'svelte/store';
+import * as uuid from 'uuid';
 
 import type { Filter } from '$lib/models/Filter';
 import type { SearchResult } from '$lib/models/Search';
 import { browser } from '$app/environment';
 import { user } from './User';
+
+const SESSION_NAMESPACE = uuid.v4();
 
 export const filters: Writable<Filter[]> = writable(restoreFilters());
 export const hasGenomicFilter: Readable<boolean> = derived(filters, ($f) =>
@@ -56,6 +59,7 @@ export function addFilter(filter: Filter) {
       currentFilters.splice(currentFilters.indexOf(f), 1);
     }
   });
+  filter.uuid = uuid.v5(JSON.stringify({ ...filter, uuid: undefined }), SESSION_NAMESPACE);
   filters.set([...currentFilters, filter]);
   return filter;
 }

--- a/src/lib/stores/ResultStore.ts
+++ b/src/lib/stores/ResultStore.ts
@@ -28,7 +28,7 @@ export async function loadPatientCount(isOpenAccess: boolean) {
       isOpenAccess,
       get(searchTerm),
       get(selectedFacets).map((facet) => facet.name),
-      get(filters).map((filter) => filter.id),
+      get(filters).map(({ uuid }) => uuid),
     ]);
     if (requestCache.has(cacheKey)) {
       resultCounts.set(requestCache.get(cacheKey) as StatResult[]);


### PR DESCRIPTION
Uses uuid-v5 to generate deterministic uuid from filter object and a random uuid generated on session start. This uuid is then used to identify filter changes that would initiate and store a new result query request.