### PR TITLE
[ALS-9325] Quick fix to add authenticate boolean

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,11 +12,13 @@ async function send({
   path,
   data,
   headers,
+  authenticate = true,
 }: {
   method: string;
   path: string;
   data?: any; //TODO: Change this
   headers?: any;
+  authenticate?: boolean;
 }) {
   const opts: { method: string; headers: { [key: string]: string }; body?: string } = {
     method,
@@ -32,7 +34,7 @@ async function send({
     opts.headers = { ...opts.headers, ...headers };
   }
 
-  if (browser) {
+  if (authenticate && browser) {
     const token = localStorage.getItem('token');
     if (token) {
       opts.headers['Authorization'] = `${BEARER}${token}`;
@@ -48,20 +50,20 @@ async function send({
   return await handleResponse(res);
 }
 
-export function get(path: string, headers?: any) {
-  return send({ method: 'GET', path, headers });
+export function get(path: string, headers?: any, authenticate?: boolean) {
+  return send({ method: 'GET', path, headers, authenticate });
 }
 
-export function del(path: string, headers?: any) {
-  return send({ method: 'DELETE', path, headers });
+export function del(path: string, headers?: any, authenticate?: boolean) {
+  return send({ method: 'DELETE', path, headers, authenticate });
 }
 
-export function post(path: string, data: any, headers?: any) {
-  return send({ method: 'POST', path, data, headers });
+export function post(path: string, data: any, headers?: any, authenticate?: boolean) {
+  return send({ method: 'POST', path, data, headers, authenticate });
 }
 
-export function put(path: string, data: any, headers?: any) {
-  return send({ method: 'PUT', path, data, headers });
+export function put(path: string, data: any, headers?: any, authenticate?: boolean) {
+  return send({ method: 'PUT', path, data, headers, authenticate });
 }
 
 async function handleResponse(res: Response) {

--- a/src/lib/components/Terms.svelte
+++ b/src/lib/components/Terms.svelte
@@ -20,7 +20,7 @@
   );
 
   function loadTermsHTML() {
-    terms = api.get(Psama.TOS + '/latest', {});
+    terms = api.get(Psama.TOS + '/latest', {}, false);
   }
 
   function accept() {


### PR DESCRIPTION
**Note**: The API call to `/latest` without authentication returns fine, but as soon as you add authentication with a user who hasn't accepted terms, it returns 403. This API issue should be resolved, but this is a quick fix that avoids that until it gets done. We shouldn't need to rip this out later, as it's just an api flag.