### PR TITLE
[ALS-11552] Update advanced query button

### DIFF
--- a/src/lib/components/explorer/results/Filters.svelte
+++ b/src/lib/components/explorer/results/Filters.svelte
@@ -5,6 +5,17 @@
 
   import FilterComponent from '$lib/components/explorer/results/AddedFilter.svelte';
   import ResultsFilterGroup from '$lib/components/explorer/results/ResultsFilterGroup.svelte';
+  import Popover from '$lib/components/Popover.svelte';
+
+  interface Props {
+    isDiscoverPage?: boolean;
+  }
+
+  let { isDiscoverPage = false }: Props = $props();
+
+  let advancedFilteringDisabled = $derived($filters.length <= 1);
+
+  const aqbBtnClass = 'btn btn-sm ml-auto preset-tonal-primary border border-primary-500';
 </script>
 
 {#if $filters.length + $genomicFilters.length + $exports.length === 0}
@@ -12,7 +23,31 @@
 {:else}
   <div class="px-4 mb-1 w-80">
     {#if $filters.length + $genomicFilters.length > 0}
-      <header class="text-left ml-1">Filters</header>
+      <div class="flex items-center m-1">
+        <header class="text-left">Filters</header>
+        {#if advancedFilteringDisabled}
+          <Popover
+            triggerTypes={['hover', 'focus']}
+            triggerStyle="ml-auto"
+            placement="left"
+            message="Advanced Query Builder is not available with only one non-genomic filter."
+          >
+            {#snippet trigger()}
+              <button data-testid="advanced-filtering-btn" class={aqbBtnClass} disabled>
+                Build Advanced Query
+              </button>
+            {/snippet}
+          </Popover>
+        {:else}
+          <a
+            href={`${isDiscoverPage ? '/discover' : '/explorer'}/advanced-filtering`}
+            data-testid="advanced-filtering-btn"
+            class="{aqbBtnClass} !mr-0 hover:preset-filled-primary-500"
+          >
+            Build Advanced Query
+          </a>
+        {/if}
+      </div>
     {/if}
     <section class="py-1">
       <ResultsFilterGroup group={$filterTree.root as FilterGroupInterface} />

--- a/src/lib/components/explorer/results/ResultsPanel.svelte
+++ b/src/lib/components/explorer/results/ResultsPanel.svelte
@@ -9,7 +9,7 @@
 
   import { features } from '$lib/configuration';
 
-  import { filters, allFilters, hasGenomicFilter, clearFilters } from '$lib/stores/Filter';
+  import { allFilters, hasGenomicFilter, clearFilters } from '$lib/stores/Filter';
   import { loadPatientCount, hasNonZeroResult, countsLoading } from '$lib/stores/ResultStore';
   import { exports, clearExports } from '$lib/stores/Export';
 
@@ -18,8 +18,6 @@
   import CardButton from '$lib/components/buttons/CardButton.svelte';
   import Modal from '$lib/components/Modal.svelte';
   import Counts from '$lib/components/explorer/results/Counts.svelte';
-  import Popover from '$lib/components/Popover.svelte';
-
   import { subscribeOnChange } from '$lib/utilities/Subscribers';
   import { log, createLog } from '$lib/logger';
 
@@ -65,10 +63,6 @@
   );
 
   let showCohortDetails = $derived(!isDiscoverPage && features.explorer.enableCohortDetails);
-
-  let nonGenomicFilterCount = $derived($filters.length);
-
-  let advancedFilteringDisabled = $derived(nonGenomicFilterCount <= 1);
 
   function subscribe() {
     unsubFilters = subscribeOnChange(allFilters, () => loadPatientCount(!isDiscoverPage));
@@ -149,12 +143,12 @@
       {#if hasFilterOrExport}
         <button
           data-testid="clear-all-results-btn"
-          class="anchor text-sm flex-none"
+          class="btn btn-xs preset-tonal-primary border border-primary-500 hover:preset-filled-primary-500 flex-none"
           onclick={() => (modalOpen = true)}>Reset</button
         >
       {/if}
     </div>
-    <Filters />
+    <Filters {isDiscoverPage} />
     {#if $exports.length > 0}
       <div class="px-4 mb-1 w-80">
         <header class="text-left ml-1" data-testid="export-header">
@@ -177,77 +171,52 @@
       </div>
     {/if}
   </div>
-  <div class="flex flex-col items-center mt-7">
-    <hr />
-    <h5 class="text-center text-xl mt-7">Tool Suite</h5>
-    <div class="flex flex-row flex-wrap justify-items-center gap-4 w-80 justify-center">
-      {#if showCohortDetails}
-        <CardButton
-          href="/explorer/cohort"
-          data-testid="cohort-details-btn"
-          title="Cohort Details"
-          icon="fa-solid fa-users"
-          size="md"
-          active={page.url.pathname.includes('explorer/cohort')}
-        />
-      {/if}
-      {#if showExplorerDistributions}
-        <CardButton
-          href="/explorer/distributions"
-          data-testid="distributions-btn"
-          title="Variable Distributions"
-          icon="fa-solid fa-chart-pie"
-          size="md"
-        />
-      {/if}
-      {#if showDiscoverDistributions}
-        <CardButton
-          href="/discover/distributions"
-          data-testid="distributions-btn"
-          title="Variable Distributions"
-          icon="fa-solid fa-chart-pie"
-          size="md"
-        />
-      {/if}
-      {#if showVariantExplorer}
-        <CardButton
-          href="/explorer/variant"
-          data-testid="variant-explorer-btn"
-          title="Variant Explorer"
-          icon="fa-solid fa-dna"
-          size="md"
-          active={page.url.pathname.includes('explorer/variant')}
-        />
-      {/if}
-      {#if advancedFilteringDisabled}
-        <Popover
-          triggerTypes={['hover', 'focus']}
-          placement="left"
-          message="Advanced Filtering is not available with only one non-genomic filter."
-        >
-          {#snippet trigger()}
-            <CardButton
-              href={`${isDiscoverPage ? '/discover' : '/explorer'}/advanced-filtering`}
-              data-testid="advanced-filtering-btn"
-              title="Advanced Filtering"
-              icon="fa-solid fa-sliders"
-              size="md"
-              disabled={advancedFilteringDisabled}
-            />
-          {/snippet}
-        </Popover>
-      {:else}
-        <CardButton
-          href={`${isDiscoverPage ? '/discover' : '/explorer'}/advanced-filtering`}
-          data-testid="advanced-filtering-btn"
-          title="Advanced Filtering"
-          icon="fa-solid fa-sliders"
-          size="md"
-          disabled={advancedFilteringDisabled}
-        />
-      {/if}
+  {#if showCohortDetails || showExplorerDistributions || showDiscoverDistributions || showVariantExplorer}
+    <div class="flex flex-col items-center mt-7">
+      <hr />
+      <h5 class="text-center text-xl mt-7">Tool Suite</h5>
+      <div class="flex flex-row flex-wrap justify-items-center gap-4 w-80 justify-center">
+        {#if showCohortDetails}
+          <CardButton
+            href="/explorer/cohort"
+            data-testid="cohort-details-btn"
+            title="Cohort Details"
+            icon="fa-solid fa-users"
+            size="md"
+            active={page.url.pathname.includes('explorer/cohort')}
+          />
+        {/if}
+        {#if showExplorerDistributions}
+          <CardButton
+            href="/explorer/distributions"
+            data-testid="distributions-btn"
+            title="Variable Distributions"
+            icon="fa-solid fa-chart-pie"
+            size="md"
+          />
+        {/if}
+        {#if showDiscoverDistributions}
+          <CardButton
+            href="/discover/distributions"
+            data-testid="distributions-btn"
+            title="Variable Distributions"
+            icon="fa-solid fa-chart-pie"
+            size="md"
+          />
+        {/if}
+        {#if showVariantExplorer}
+          <CardButton
+            href="/explorer/variant"
+            data-testid="variant-explorer-btn"
+            title="Variant Explorer"
+            icon="fa-solid fa-dna"
+            size="md"
+            active={page.url.pathname.includes('explorer/variant')}
+          />
+        {/if}
+      </div>
     </div>
-  </div>
+  {/if}
 </section>
 
 <style>

--- a/tests/end-to-end/advanced-filtering/tool-suite-test.ts
+++ b/tests/end-to-end/advanced-filtering/tool-suite-test.ts
@@ -13,7 +13,7 @@ import { clickNthFilterIcon, getOption } from '../utils';
 
 const SYNC_URL = '*/**/picsure/query/sync';
 
-test.describe('Advanced Filtering - Tool Suite', () => {
+test.describe('Advanced Query Builder - Build Advanced Query Button', () => {
   test.use({ storageState: 'tests/end-to-end/.auth/generalUser.json' });
 
   test.beforeEach(async ({ page }) => {
@@ -22,10 +22,9 @@ test.describe('Advanced Filtering - Tool Suite', () => {
     await mockApiSuccess(page, SYNC_URL, '9999');
   });
 
-  test('AF-TOOL-001: Tool Suite contains an Advanced Filtering item with sliders icon', async ({
+  test('AF-TOOL-001: Build Advanced Query button appears next to Filters heading with two filters', async ({
     page,
   }) => {
-    // Navigate to the explorer page
     await mockApiSuccess(
       page,
       `${conceptsDetailPath}/${detailResponseCat.dataset}`,
@@ -33,59 +32,32 @@ test.describe('Advanced Filtering - Tool Suite', () => {
     );
     await page.goto('/explorer?search=somedata');
 
-    // Add first filter via row 0
+    // Add first filter
     await clickNthFilterIcon(page, 0);
     const firstItem = await getOption(page);
     await firstItem.click();
     await page.getByTestId('add-filter').click();
 
-    // Re-mock detail endpoint for the second row's data
+    // Add second filter
     await mockApiSuccess(
       page,
       `${conceptsDetailPath}/${detailResponseCatSameDataset.dataset}`,
       detailResponseCatSameDataset,
     );
-
-    // Add second filter via row 1
     await clickNthFilterIcon(page, 1);
     const secondItem = await getOption(page);
     await secondItem.click();
     await page.getByTestId('add-filter').click();
 
-    // Wait for the results panel to be visible
     await expect(page.locator('#results-panel')).toBeVisible();
 
-    // Verify the Tool Suite heading is visible
-    await expect(page.getByText('Tool Suite')).toBeVisible();
-
-    // Verify the Advanced Filtering button exists in the Tool Suite
+    // Verify the Build Advanced Query button exists next to Filters
     const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
     await expect(advancedFilteringBtn).toBeVisible();
-
-    // Verify the button title is "Advanced Filtering"
-    await expect(advancedFilteringBtn).toContainText('Advanced Filtering');
-
-    // Verify the icon is the Font Awesome sliders icon (fa-sliders)
-    const icon = advancedFilteringBtn.locator('i.fa-sliders');
-    await expect(icon).toBeVisible();
+    await expect(advancedFilteringBtn).toContainText('Build Advanced Query');
   });
 
-  test('AF-TOOL-002: Advanced Filtering tool is disabled when no filters are added', async ({
-    page,
-  }) => {
-    await page.goto('/explorer?search=somedata');
-
-    // Open the side panel (it starts closed when no filters exist)
-    await page.locator('#results-panel-toggle').click();
-    await expect(page.locator('#results-panel')).toBeVisible();
-
-    // Verify the Advanced Filtering button is visible but disabled
-    const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
-    await expect(advancedFilteringBtn).toBeVisible();
-    await expect(advancedFilteringBtn).toBeDisabled();
-  });
-
-  test('AF-TOOL-003: Advanced Filtering tool becomes enabled when a second filter is added', async ({
+  test('AF-TOOL-002: Build Advanced Query button is disabled with only one filter', async ({
     page,
   }) => {
     await mockApiSuccess(
@@ -95,20 +67,37 @@ test.describe('Advanced Filtering - Tool Suite', () => {
     );
     await page.goto('/explorer?search=somedata');
 
-    // Open the side panel (it starts closed when no filters exist)
-    await page.locator('#results-panel-toggle').click();
-    await expect(page.locator('#results-panel')).toBeVisible();
-
-    // Verify button starts disabled
-    const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
-    await expect(advancedFilteringBtn).toBeVisible();
-    await expect(advancedFilteringBtn).toBeDisabled();
-
-    // Add first filter — button should still be disabled (needs > 1)
+    // Add one filter
     await clickNthFilterIcon(page, 0);
     const firstItem = await getOption(page);
     await firstItem.click();
     await page.getByTestId('add-filter').click();
+
+    await expect(page.locator('#results-panel')).toBeVisible();
+
+    // Verify the button is visible but disabled
+    const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
+    await expect(advancedFilteringBtn).toBeVisible();
+    await expect(advancedFilteringBtn).toBeDisabled();
+  });
+
+  test('AF-TOOL-003: Build Advanced Query button becomes enabled when a second filter is added', async ({
+    page,
+  }) => {
+    await mockApiSuccess(
+      page,
+      `${conceptsDetailPath}/${detailResponseCat.dataset}`,
+      detailResponseCat,
+    );
+    await page.goto('/explorer?search=somedata');
+
+    // Add first filter — button should be disabled (needs > 1)
+    await clickNthFilterIcon(page, 0);
+    const firstItem = await getOption(page);
+    await firstItem.click();
+    await page.getByTestId('add-filter').click();
+
+    const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
     await expect(advancedFilteringBtn).toBeDisabled();
 
     // Add second filter
@@ -126,7 +115,7 @@ test.describe('Advanced Filtering - Tool Suite', () => {
     await expect(advancedFilteringBtn).toBeEnabled();
   });
 
-  test('AF-TOOL-004: Clicking Advanced Filtering tool navigates to the Advanced Filtering page', async ({
+  test('AF-TOOL-004: Clicking Build Advanced Query navigates to the Advanced Query Builder page', async ({
     page,
   }) => {
     await mockApiSuccess(
@@ -152,12 +141,12 @@ test.describe('Advanced Filtering - Tool Suite', () => {
     await secondItem.click();
     await page.getByTestId('add-filter').click();
 
-    // Click the Advanced Filtering button
+    // Click the Build Advanced Query button
     const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
     await expect(advancedFilteringBtn).toBeEnabled();
     await advancedFilteringBtn.click();
 
-    // Verify the Advanced Filtering page opens
+    // Verify the Advanced Query Builder page opens
     await page.waitForURL(/\/explorer\/advanced-filtering/);
     await expect(page.getByRole('heading', { name: 'Advanced Query Builder' })).toBeVisible();
   });
@@ -192,7 +181,7 @@ test.describe('Advanced Filtering - Tool Suite', () => {
     // Wait for results panel to appear
     await expect(page.locator('#results-panel')).toBeVisible();
 
-    // Navigate to the Advanced Filtering page
+    // Navigate to the Advanced Query Builder page
     const advancedFilteringBtn = page.getByTestId('advanced-filtering-btn');
     await expect(advancedFilteringBtn).toBeEnabled();
     await advancedFilteringBtn.click();


### PR DESCRIPTION
“Reset” option next to Filtered Data Summary should be a small button in primary color

Remove Advanced Filtering from Tool Suite

Add button next to Filters that says “Build Advanced Query"

Clicking the Build Advanced Query should take the user to the Advanced Query Builder page