### PR TITLE
[ALS-11705]  Use V3 Query for Visualizations

### DIFF
--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -8,28 +8,29 @@
     createContinuousPlot,
     createCategoryPlot,
   } from '$lib/utilities/Plotly';
-  import { getQueryRequestV2 } from '$lib/utilities/QueryBuilder';
+  import { getQueryRequestV3 } from '$lib/utilities/QueryBuilder';
   import { toaster } from '$lib/toaster';
   import Loading from '$lib/components/Loading.svelte';
   import { Picsure } from '$lib/paths';
   import { resources } from '$lib/stores/Resources';
   import { isOpenAccess } from '$lib/AccessState';
+  import LogicTreeSummary from '$lib/components/explorer/advanced/LogicTreeSummary.svelte';
+  import { filterTree, genomicFilters } from '$lib/stores/Filter';
+  import { type FilterGroupInterface } from '$lib/models/Filter.svelte';
 
   let plotValues: PlotValues[] = $state([]);
   let newPlot: PlotlyNewPlot = $state() as PlotlyNewPlot;
   let loading = $state(true);
 
   async function loadPlotData() {
-    const query = getQueryRequestV2(!isOpenAccess(), $resources.visualization);
-    const token = localStorage.getItem('token');
+    const query = getQueryRequestV3(!isOpenAccess(), $resources.visualization);
 
     await api
       .post(
-        Picsure.QueryV3Sync,
+        Picsure.Visualization.Distributions,
         {
           query: query.query,
-          resourceUUID: $resources.visualization,
-          resourceCredentials: token ? { Authorization: 'Bearer ' + token } : {},
+          hpdsResourceUUID: isOpenAccess() ? $resources.hpdsOpenV3 : $resources.hpdsAuth,
         },
         undefined,
         !isOpenAccess(),
@@ -63,6 +64,11 @@
 <p class="mb-8 text-center">
   All visualizations display the distributions of each variable filter for the specified cohort.
 </p>
+<LogicTreeSummary
+  root={$filterTree.root as FilterGroupInterface}
+  genomicFilters={$genomicFilters}
+  widthClass="w-3/4"
+/>
 <div id="visualizations" class="flex flex-row flex-wrap gap-6 items-center justify-center">
   {#if loading}
     <Loading ring size="medium" />

--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -11,17 +11,26 @@
     createCategoryPlot,
   } from '$lib/utilities/Plotly';
   import { getQueryRequestV3 } from '$lib/utilities/QueryBuilder';
+  import {
+    categoricalHasData,
+    continuousHasData,
+    getExcludedVisualizationVariables,
+    getIncludedConceptPaths,
+    isVisualizationFilter,
+  } from '$lib/utilities/VisualizationData';
   import { toaster } from '$lib/toaster';
   import Loading from '$lib/components/Loading.svelte';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import { Picsure } from '$lib/paths';
   import { resources } from '$lib/stores/Resources';
   import { isOpenAccess } from '$lib/AccessState';
   import LogicTreeSummary from '$lib/components/explorer/advanced/LogicTreeSummary.svelte';
-  import { allFilters, filterTree, genomicFilters } from '$lib/stores/Filter';
+  import { filters, filterTree, genomicFilters } from '$lib/stores/Filter';
   import { type Filter, type FilterGroupInterface } from '$lib/models/Filter.svelte';
   import { get } from 'svelte/store';
 
   let plotValues: PlotValues[] = $state([]);
+  let excludedVariables: string[] = $state([]);
   let newPlot: PlotlyNewPlot = $state() as PlotlyNewPlot;
   let loading = $state(true);
 
@@ -40,7 +49,10 @@
   }
 
   async function loadPlotData() {
-    const subtitleByConceptPath = getSubtitleByConceptPath(get(allFilters));
+    const plotFilters = get(filters);
+    const visualizationFilters = plotFilters.filter(isVisualizationFilter);
+    const subtitleByConceptPath = getSubtitleByConceptPath(plotFilters);
+    const minimumCount = isOpenAccess() ? 9 : 1;
 
     const getSubtitle = (conceptPath?: string) =>
       conceptPath ? subtitleByConceptPath.get(conceptPath) : undefined;
@@ -64,11 +76,24 @@
         !isOpenAccess(),
       )
       .then((resp) => {
+        const categoricalData = (resp?.categoricalData || []).filter((data: CategoricalPlotData) =>
+          categoricalHasData(data, minimumCount),
+        );
+        const continuousData = (resp?.continuousData || []).filter((data: ContinuousPlotData) =>
+          continuousHasData(data, minimumCount),
+        );
+        const includedConceptPaths = getIncludedConceptPaths(categoricalData, continuousData);
+
+        excludedVariables = getExcludedVisualizationVariables(
+          visualizationFilters,
+          includedConceptPaths,
+        );
+
         plotValues = [
-          ...(resp?.categoricalData || []).map((data: CategoricalPlotData) =>
+          ...categoricalData.map((data: CategoricalPlotData) =>
             createCategoryPlot(withSubtitle(data)),
           ),
-          ...(resp?.continuousData || []).map((data: ContinuousPlotData) =>
+          ...continuousData.map((data: ContinuousPlotData) =>
             createContinuousPlot(withSubtitle(data)),
           ),
         ];
@@ -77,7 +102,7 @@
         console.error('Viusalzation failed with query: ' + JSON.stringify(query), error);
         toaster.error({
           description:
-            'An error occured while parsing your token. Please try again later. If this problem persists, please contact an administrator.',
+            'An error occured while loading your visualization(s). Please try again later. If this problem persists, please contact an administrator.',
         });
       })
       .finally(() => {
@@ -101,6 +126,22 @@
   genomicFilters={$genomicFilters}
   widthClass="w-3/4"
 />
+{#if excludedVariables.length}
+  <div class="w-3/4 mx-auto my-4">
+    <ErrorAlert color="warning" iconSize="2xl" data-testid="excluded-visualizations-warning">
+      <p>
+        Some variables were excluded from visualization because there was insufficient participant
+        data for the selected query.
+      </p>
+      <p class="font-bold mt-2">Variables not included:</p>
+      <ul class="list-disc list-inside">
+        {#each excludedVariables as variable}
+          <li>{variable}</li>
+        {/each}
+      </ul>
+    </ErrorAlert>
+  </div>
+{/if}
 <div id="visualizations" class="flex flex-row flex-wrap gap-6 items-center justify-center">
   {#if loading}
     <Loading ring size="medium" />

--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -5,6 +5,8 @@
   import {
     type PlotValues,
     type PlotlyNewPlot,
+    type CategoricalPlotData,
+    type ContinuousPlotData,
     createContinuousPlot,
     createCategoryPlot,
   } from '$lib/utilities/Plotly';
@@ -15,14 +17,40 @@
   import { resources } from '$lib/stores/Resources';
   import { isOpenAccess } from '$lib/AccessState';
   import LogicTreeSummary from '$lib/components/explorer/advanced/LogicTreeSummary.svelte';
-  import { filterTree, genomicFilters } from '$lib/stores/Filter';
-  import { type FilterGroupInterface } from '$lib/models/Filter.svelte';
+  import { allFilters, filterTree, genomicFilters } from '$lib/stores/Filter';
+  import { type Filter, type FilterGroupInterface } from '$lib/models/Filter.svelte';
+  import { get } from 'svelte/store';
 
   let plotValues: PlotValues[] = $state([]);
   let newPlot: PlotlyNewPlot = $state() as PlotlyNewPlot;
   let loading = $state(true);
 
+  function getSubtitleByConceptPath(filters: Filter[]) {
+    return new Map(
+      filters.map((filter) => [
+        filter.id,
+        [
+          filter.searchResult?.studyAcronym && `Study: ${filter.searchResult.studyAcronym}`,
+          filter.searchResult?.dataset && `Dataset: ${filter.searchResult.dataset}`,
+        ]
+          .filter(Boolean)
+          .join(' '),
+      ]),
+    );
+  }
+
   async function loadPlotData() {
+    const subtitleByConceptPath = getSubtitleByConceptPath(get(allFilters));
+
+    const getSubtitle = (conceptPath?: string) =>
+      conceptPath ? subtitleByConceptPath.get(conceptPath) : undefined;
+    const withSubtitle = <T extends { conceptPath?: string }>(
+      data: T,
+    ): T & { subtitle?: string } => ({
+      ...data,
+      subtitle: getSubtitle(data.conceptPath),
+    });
+
     const query = getQueryRequestV3(!isOpenAccess(), $resources.visualization);
 
     await api
@@ -37,8 +65,12 @@
       )
       .then((resp) => {
         plotValues = [
-          ...(resp?.categoricalData || []).map(createCategoryPlot),
-          ...(resp?.continuousData || []).map(createContinuousPlot),
+          ...(resp?.categoricalData || []).map((data: CategoricalPlotData) =>
+            createCategoryPlot(withSubtitle(data)),
+          ),
+          ...(resp?.continuousData || []).map((data: ContinuousPlotData) =>
+            createContinuousPlot(withSubtitle(data)),
+          ),
         ];
       })
       .catch((error) => {

--- a/src/lib/components/explorer/advanced/LogicTreeSummary.svelte
+++ b/src/lib/components/explorer/advanced/LogicTreeSummary.svelte
@@ -9,15 +9,16 @@
   interface Props {
     root: FilterGroupInterface;
     genomicFilters?: FilterInterface[];
+    widthClass?: string;
   }
 
-  let { root, genomicFilters = [] }: Props = $props();
+  let { root, genomicFilters = [], widthClass = 'w-full' }: Props = $props();
 
   let parts: EquationPart[] = $derived(buildEquation(root, genomicFilters));
   let accordionValue: string[] = $state(['logic-tree']);
 </script>
 
-<div class="mb-4 w-full" data-testid="logic-tree-summary">
+<div class="mb-4 mx-auto {widthClass}" data-testid="logic-tree-summary">
   <Accordion value={accordionValue} onValueChange={(e) => (accordionValue = e.value)} collapsible>
     {#snippet iconOpen()}<i class="fa-solid fa-angle-up"></i>{/snippet}
     {#snippet iconClosed()}<i class="fa-solid fa-angle-down"></i>{/snippet}

--- a/src/lib/components/explorer/results/ResultsPanel.svelte
+++ b/src/lib/components/explorer/results/ResultsPanel.svelte
@@ -10,7 +10,12 @@
   import { features } from '$lib/configuration';
 
   import { allFilters, hasGenomicFilter, clearFilters } from '$lib/stores/Filter';
-  import { loadPatientCount, hasNonZeroResult, countsLoading } from '$lib/stores/ResultStore';
+  import {
+    loadPatientCount,
+    hasNonZeroResult,
+    countsLoading,
+    totalParticipants,
+  } from '$lib/stores/ResultStore';
   import { exports, clearExports } from '$lib/stores/Export';
 
   import Filters from '$lib/components/explorer/results/Filters.svelte';
@@ -60,6 +65,17 @@
 
   let showVariantExplorer = $derived(
     !isDiscoverPage && features.explorer.variantExplorer && $hasGenomicFilter,
+  );
+
+  function isObfuscatedLessThanTen(count: unknown) {
+    return typeof count === 'string' && count.trim().startsWith('<');
+  }
+
+  let distributionsDisabled = $derived(
+    $countsLoading ||
+      (isDiscoverPage
+        ? isObfuscatedLessThanTen($totalParticipants) || $totalParticipants < 10
+        : $totalParticipants === 0),
   );
 
   let showCohortDetails = $derived(!isDiscoverPage && features.explorer.enableCohortDetails);
@@ -193,6 +209,7 @@
             title="Variable Distributions"
             icon="fa-solid fa-chart-pie"
             size="md"
+            disabled={distributionsDisabled}
           />
         {/if}
         {#if showDiscoverDistributions}
@@ -202,6 +219,7 @@
             title="Variable Distributions"
             icon="fa-solid fa-chart-pie"
             size="md"
+            disabled={distributionsDisabled}
           />
         {/if}
         {#if showVariantExplorer}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -2,6 +2,7 @@ const PREFIX = 'picsure';
 const DICT = `${PREFIX}/proxy/dictionary-api`;
 const QUERY = `${PREFIX}/query`;
 const UPLOADER = `${PREFIX}/proxy/uploader`;
+const VIZ = `${PREFIX}/proxy/visualization`;
 const API = '/api/v1';
 
 export const Picsure = {
@@ -28,6 +29,9 @@ export const Picsure = {
     Upload: `${UPLOADER}/upload`,
     Sites: `${UPLOADER}/sites`,
     Status: `${UPLOADER}/status`,
+  },
+  Visualization: {
+    Distributions: `${VIZ}/distributions`,
   },
 };
 

--- a/src/lib/utilities/Plotly.ts
+++ b/src/lib/utilities/Plotly.ts
@@ -31,6 +31,8 @@ export type PlotlyNewPlot = (
 
 type PlotData = {
   title: string;
+  conceptPath?: string;
+  subtitle?: string;
   continuous: boolean;
   colors: string[];
   chartWidth: number;
@@ -66,6 +68,10 @@ function getColors(num: number) {
     colors.push(defaultColors[i % defaultColors.length]);
   }
   return colors;
+}
+
+function getSubTitle(inData: CategoricalPlotData | ContinuousPlotData) {
+  return inData.subtitle || '';
 }
 
 function shortenTitle(title: string) {
@@ -108,6 +114,7 @@ export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
 
   const colors: string[] = getColors(values.length);
   const title = shortenTitle(inData.title);
+  const subtitle = getSubTitle(inData);
   const data: Data[] = [
     {
       x: Object.keys(inData.categoricalMap),
@@ -144,6 +151,9 @@ export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
   const layout: Partial<Layout> = {
     title: {
       text: title,
+      subtitle: {
+        text: subtitle,
+      },
     },
     width: inData.chartWidth || 500,
     height: inData.chartHeight || 600,
@@ -208,8 +218,8 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
     });
 
   const { topBar, bottomBar } = obfuscateData(orderedValues, isObfuscated);
-
   const title = shortenTitle(inData.title);
+  const subtitle = getSubTitle(inData);
   const data: Data[] = [
     {
       x: orderedKeys,
@@ -251,6 +261,9 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
   const layout: Partial<Layout> = {
     title: {
       text: title,
+      subtitle: {
+        text: subtitle,
+      },
     },
     width: inData.chartWidth || 500,
     height: inData.chartHeight || 600,

--- a/src/lib/utilities/VisualizationData.ts
+++ b/src/lib/utilities/VisualizationData.ts
@@ -1,0 +1,47 @@
+import type { CategoricalPlotData, ContinuousPlotData } from '$lib/utilities/Plotly';
+import type { Filter } from '$lib/models/Filter.svelte';
+
+export type VisualizationPlotData = CategoricalPlotData | ContinuousPlotData;
+
+export function isVisualizationFilter(filter: Filter) {
+  return !['genomic', 'snp', 'AnyRecordOf', 'FilterGroup'].includes(filter.filterType);
+}
+
+export function visualizationVariableLabel(filter: Filter) {
+  const label =
+    filter.searchResult?.display || filter.variableName || filter.searchResult?.name || filter.id;
+  const study = filter.searchResult?.studyAcronym || filter.searchResult?.dataset;
+  return study ? `${study} - ${label}` : label;
+}
+
+export function totalMapCount(map?: Record<string, number>) {
+  return Object.values(map || {}).reduce((total, value) => total + Number(value || 0), 0);
+}
+
+export function categoricalHasData(data: CategoricalPlotData, minimumCount: number) {
+  return totalMapCount(data.categoricalMap) >= minimumCount;
+}
+
+export function continuousHasData(data: ContinuousPlotData, minimumCount: number) {
+  return totalMapCount(data.continuousMap) >= minimumCount;
+}
+
+export function getIncludedConceptPaths(
+  categoricalData: CategoricalPlotData[],
+  continuousData: ContinuousPlotData[],
+) {
+  return new Set([
+    ...categoricalData.map((data) => data.conceptPath),
+    ...continuousData.map((data) => data.conceptPath),
+  ]);
+}
+
+export function getExcludedVisualizationVariables(
+  filters: Filter[],
+  includedConceptPaths: Set<string | undefined>,
+) {
+  return filters
+    .filter(isVisualizationFilter)
+    .filter((filter) => !includedConceptPaths.has(filter.id))
+    .map(visualizationVariableLabel);
+}

--- a/tests/end-to-end/explorer/visualizations/test.ts
+++ b/tests/end-to-end/explorer/visualizations/test.ts
@@ -1,0 +1,115 @@
+import { expect, type Route } from '@playwright/test';
+import { test, mockApiSuccess } from '../../custom-context';
+import {
+  conceptsDetailPath,
+  detailResponseCat,
+  detailResponseCat2,
+  facetResultPath,
+  facetsResponse,
+  searchResults as mockData,
+  searchResultPath,
+} from '../../mock-data';
+import { getOption } from '../../utils';
+
+const countResultPath = '*/**/picsure/v3/query/sync';
+const distributionsPath = '*/**/picsure/proxy/visualization/distributions';
+
+async function addFilterFromRow(page: import('@playwright/test').Page, rowIndex: number) {
+  await page.locator(`#row-${rowIndex} button[title=Filter]`).click();
+  const firstItem = await getOption(page);
+  await firstItem.click();
+  await page.getByTestId('add-filter').click();
+}
+
+test.describe('Variable Distributions visualizations', () => {
+  test.use({ storageState: 'tests/end-to-end/.auth/generalUser.json' });
+
+  test.beforeEach(async ({ page }) => {
+    await mockApiSuccess(page, searchResultPath, mockData);
+    await mockApiSuccess(page, facetResultPath, facetsResponse);
+    await mockApiSuccess(page, countResultPath, '9999');
+    await page.route(`${conceptsDetailPath}/${detailResponseCat.dataset}`, async (route: Route) => {
+      const requestBody = route.request().postData() || '';
+      if (requestBody.includes(detailResponseCat2.conceptPath)) {
+        await route.fulfill({ json: detailResponseCat2 });
+        return;
+      }
+      await route.fulfill({ json: detailResponseCat });
+    });
+  });
+
+  test('shows an insufficient data warning for empty returned charts and graphs charts with data', async ({
+    page,
+  }) => {
+    await mockApiSuccess(page, distributionsPath, {
+      categoricalData: [
+        {
+          title: detailResponseCat.display,
+          conceptPath: detailResponseCat.conceptPath,
+          categoricalMap: {},
+          obfuscated: false,
+          xaxisName: detailResponseCat.display,
+          yaxisName: 'Participants',
+        },
+        {
+          title: detailResponseCat2.display,
+          conceptPath: detailResponseCat2.conceptPath,
+          categoricalMap: { Yes: 12, No: 4 },
+          obfuscated: false,
+          xaxisName: detailResponseCat2.display,
+          yaxisName: 'Participants',
+        },
+      ],
+      continuousData: [],
+    });
+
+    await page.goto('/explorer?search=somedata');
+    await addFilterFromRow(page, 0);
+    await addFilterFromRow(page, 2);
+    await page.getByTestId('distributions-btn').click();
+
+    const warning = page.getByTestId('excluded-visualizations-warning');
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText(
+      'Some variables were excluded from visualization because there was insufficient participant data for the selected query.',
+    );
+    await expect(warning).toContainText(`TDS - ${detailResponseCat.display}`);
+    await expect(
+      page.locator('[aria-label="Column chart showing the visualization of Any tests today?"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        '[aria-label="Column chart showing the visualization of Any family with heart attack?"]',
+      ),
+    ).not.toBeVisible();
+  });
+
+  test('does not show the insufficient data warning when all returned charts have data', async ({
+    page,
+  }) => {
+    await mockApiSuccess(page, distributionsPath, {
+      categoricalData: [
+        {
+          title: detailResponseCat.display,
+          conceptPath: detailResponseCat.conceptPath,
+          categoricalMap: { Yes: 1 },
+          obfuscated: false,
+          xaxisName: detailResponseCat.display,
+          yaxisName: 'Participants',
+        },
+      ],
+      continuousData: [],
+    });
+
+    await page.goto('/explorer?search=somedata');
+    await addFilterFromRow(page, 0);
+    await page.getByTestId('distributions-btn').click();
+
+    await expect(page.getByTestId('excluded-visualizations-warning')).not.toBeVisible();
+    await expect(
+      page.locator(
+        '[aria-label="Column chart showing the visualization of Any family with heart attack?"]',
+      ),
+    ).toBeVisible();
+  });
+});

--- a/tests/end-to-end/results-panel/test.ts
+++ b/tests/end-to-end/results-panel/test.ts
@@ -287,7 +287,7 @@ test.describe('Results Panel', () => {
       await mockApiSuccess(page, '*/**/picsure/search/2', crossCountSyncResponseInital);
       await mockApiSuccess(page, facetResultPath, facetsResponse);
       await mockApiSuccess(page, searchResultPath, mockData);
-      await mockApiSuccess(page, openCountResultPath, '9999');
+      await mockApiSuccess(page, openCountResultPath, { '\\_studies_consents\\': 9999 });
       await page.goto('/discover?search=somedata');
       await mockApiSuccess(
         page,
@@ -314,6 +314,56 @@ test.describe('Results Panel', () => {
 
       // Then
       await expect(page.getByTestId('distributions-btn')).not.toBeDisabled();
+    });
+
+    test('disables distributions button on Explore when total cohort count is zero', async ({
+      page,
+    }) => {
+      // Given
+      await mockApiSuccess(page, facetResultPath, facetsResponse);
+      await mockApiSuccess(page, searchResultPath, mockData);
+      await mockApiSuccess(page, countResultPath, '0');
+      await mockApiSuccess(
+        page,
+        `${conceptsDetailPath}/${detailResponseCat.dataset}`,
+        detailResponseCat,
+      );
+      await page.goto('/explorer?search=somedata');
+
+      // When
+      await page.locator('#row-0 button[title=Filter]').click();
+      const firstItem = await getOption(page);
+      await firstItem.click();
+      await page.getByTestId('add-filter').click();
+
+      // Then
+      await expect(page.getByTestId('distributions-btn')).toBeDisabled();
+    });
+
+    test('disables distributions button on Discover when total cohort count is less than ten', async ({
+      page,
+    }) => {
+      // Given
+      await mockApiSuccess(page, '*/**/picsure/search/2', crossCountSyncResponseInital);
+      await mockApiSuccess(page, facetResultPath, facetsResponse);
+      await mockApiSuccess(page, searchResultPath, mockData);
+      await mockApiSuccess(page, openCountResultPath, { '\\_studies_consents\\': '< 10' });
+      await mockApiSuccess(
+        page,
+        `${conceptsDetailPath}/${detailResponseCat.dataset}`,
+        detailResponseCat,
+      );
+      await page.goto('/discover?search=somedata');
+
+      // When
+      await page.locator('#row-0 button[title=Filter]').click();
+      await page.locator('#options-container label:nth-child(1)').click();
+      const firstItem = await getOption(page);
+      await firstItem.click();
+      await page.getByTestId('add-filter').click();
+
+      // Then
+      await expect(page.getByTestId('distributions-btn')).toBeDisabled();
     });
 
     test('sends request with QueryV3 structure', async ({ page }) => {

--- a/tests/unit/VisualizationData.test.ts
+++ b/tests/unit/VisualizationData.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  categoricalHasData,
+  continuousHasData,
+  getExcludedVisualizationVariables,
+  getIncludedConceptPaths,
+  isVisualizationFilter,
+  visualizationVariableLabel,
+} from '$lib/utilities/VisualizationData';
+import type { CategoricalPlotData, ContinuousPlotData } from '$lib/utilities/Plotly';
+import type { Filter } from '$lib/models/Filter.svelte';
+
+function categorical(conceptPath: string | undefined, categoricalMap: Record<string, number>) {
+  return { conceptPath, categoricalMap } as CategoricalPlotData;
+}
+
+function continuous(conceptPath: string | undefined, continuousMap: Record<string, number>) {
+  return { conceptPath, continuousMap } as ContinuousPlotData;
+}
+
+function filter(overrides: Partial<Filter> = {}) {
+  return {
+    id: '\\study\\variable\\',
+    filterType: 'Categorical',
+    variableName: 'Variable name',
+    searchResult: {
+      display: 'Display label',
+      name: 'Search result name',
+      studyAcronym: 'STUDY',
+      dataset: 'dataset',
+    },
+    ...overrides,
+  } as Filter;
+}
+
+describe('VisualizationData', () => {
+  it('treats empty and zero categorical charts as insufficient', () => {
+    expect(categoricalHasData(categorical('empty', {}), 1)).toBe(false);
+    expect(categoricalHasData(categorical('zero', { Yes: 0, No: 0 }), 1)).toBe(false);
+  });
+
+  it('uses minimum count threshold for categorical and continuous charts', () => {
+    expect(categoricalHasData(categorical('cat', { Yes: 9 }), 9)).toBe(true);
+    expect(categoricalHasData(categorical('cat', { Yes: 8 }), 9)).toBe(false);
+    expect(continuousHasData(continuous('con', { '0 - 10': 9 }), 9)).toBe(true);
+    expect(continuousHasData(continuous('con', { '0 - 10': 8 }), 9)).toBe(false);
+  });
+
+  it('excludes selected visualization filters missing from graphable response data', () => {
+    const included = getIncludedConceptPaths(
+      [categorical('\\study\\included\\', { Yes: 10 })],
+      [continuous('\\study\\continuous\\', { '0 - 10': 10 })],
+    );
+
+    expect(
+      getExcludedVisualizationVariables(
+        [
+          filter({ id: '\\study\\included\\' }),
+          filter({ id: '\\study\\excluded\\', variableName: 'Excluded variable' }),
+        ],
+        included,
+      ),
+    ).toEqual(['STUDY - Display label']);
+  });
+
+  it('does not consider genomic, snp, AnyRecordOf, or groups visualization filters', () => {
+    expect(isVisualizationFilter(filter({ filterType: 'Categorical' }))).toBe(true);
+    expect(isVisualizationFilter(filter({ filterType: 'numeric' }))).toBe(true);
+    expect(isVisualizationFilter(filter({ filterType: 'genomic' }))).toBe(false);
+    expect(isVisualizationFilter(filter({ filterType: 'snp' }))).toBe(false);
+    expect(isVisualizationFilter(filter({ filterType: 'AnyRecordOf' }))).toBe(false);
+    expect(isVisualizationFilter(filter({ filterType: 'FilterGroup' }))).toBe(false);
+  });
+
+  it('formats variable labels with display, variableName, search result name fallback order', () => {
+    expect(visualizationVariableLabel(filter())).toBe('STUDY - Display label');
+    expect(
+      visualizationVariableLabel(
+        filter({
+          variableName: 'Variable fallback',
+          searchResult: { name: 'Name fallback', studyAcronym: 'STUDY' } as Filter['searchResult'],
+        }),
+      ),
+    ).toBe('STUDY - Variable fallback');
+    expect(
+      visualizationVariableLabel(
+        filter({
+          variableName: '',
+          searchResult: { name: 'Name fallback', dataset: 'dataset' } as Filter['searchResult'],
+        }),
+      ),
+    ).toBe('dataset - Name fallback');
+  });
+});


### PR DESCRIPTION
Updates Visualization Distribution tool to use the V3 visualization distribution endpoint, show the cohort logic summary above charts, and add study/dataset context subtitles to generated Plotly visualizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plot visualizations now show dynamic subtitles built from active filters.
  * Added a filter-summary header above the visualizations list.
  * Shows a warning when selected variables are excluded from visualization.

* **Improvements**
  * Improved title/subtitle rendering for categorical and continuous distributions.
  * Distribution navigation buttons are disabled while counts load or when cohort totals are below thresholds.

* **Tests**
  * New end-to-end and unit tests covering visualization behaviors and button states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hms-dbmi/PIC-SURE-Frontend/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->