### PR TITLE
[ALS-11281] Display meta key-value pairs in info component

### DIFF
--- a/src/lib/assets/configuration.json
+++ b/src/lib/assets/configuration.json
@@ -74,6 +74,11 @@
         "dataElement": "name"
       }
     ],
+    "resultInfo": {
+      "variableHeader": "Variable Information",
+      "datasetHeader": "Dataset Information",
+      "studyHeader": "Study Information"
+    },
     "tourSearchIntro": "PIC-SURE Search allows you to search for variable level data.",
     "totalPatientsText": "Filtered Participants",
     "queryErrorText": "There was an error with your query. If this persists, please contact your PIC-SURE admin.",

--- a/src/lib/components/buttons/ShowMoreButton.svelte
+++ b/src/lib/components/buttons/ShowMoreButton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  interface Props {
+    expanded: boolean;
+    onclick?: () => void;
+    class?: string;
+    lessLabel?: string;
+    moreLabel?: string;
+    'data-testid'?: string;
+    'data-testId'?: string;
+  }
+
+  const {
+    expanded,
+    onclick = () => {},
+    class: className = '',
+    lessLabel = 'Show Less',
+    moreLabel = 'Show More',
+    'data-testid': dataTestId = '',
+    'data-testId': legacyDataTestId = '',
+  }: Props = $props();
+
+  const testId = $derived(dataTestId || legacyDataTestId || 'show-more');
+</script>
+
+<button
+  data-testid={testId}
+  type="button"
+  class="show-more w-fit mx-auto my-1 {className}"
+  {onclick}
+>
+  {expanded ? lessLabel : moreLabel}
+  <i class="ml-1 fa-solid fa-angle-{expanded ? 'up' : 'down'}"></i>
+</button>
+
+<style lang="postcss">
+  @reference "../../../styles/app.css";
+
+  .show-more {
+    @apply btn btn-sm preset-outlined-surface-500 rounded-container;
+  }
+</style>

--- a/src/lib/components/explorer/FacetCategory.svelte
+++ b/src/lib/components/explorer/FacetCategory.svelte
@@ -8,6 +8,7 @@
   import { hiddenFacets, openFacets } from '$lib/stores/Dictionary';
   import { log, createLog, getPageContext } from '$lib/logger';
 
+  import ShowMoreButton from '$lib/components/buttons/ShowMoreButton.svelte';
   import FacetItem from './FacetItem.svelte';
 
   interface Props {
@@ -172,14 +173,11 @@
         <FacetItem {facet} {facetCategory} {textFilterValue} />
       {/each}
       {#if overShowLimit && !textFilterValue}
-        <button
-          data-testId="show-more-facets"
-          class="show-more w-fit mx-auto my-1"
+        <ShowMoreButton
+          data-testid="show-more-facets"
+          expanded={showMore}
           onclick={() => (showMore = !showMore)}
-        >
-          {showMore ? 'Show Less' : 'Show More'}
-          <i class="ml-1 fa-solid fa-angle-{showMore ? 'up' : 'down'}"></i>
-        </button>
+        />
       {/if}
     </div>
   {/snippet}
@@ -202,11 +200,3 @@
     {/each}
   </div>
 {/if}
-
-<style lang="postcss">
-  @reference "../../../styles/app.css";
-
-  .show-more {
-    @apply btn btn-sm preset-outlined-surface-500 rounded-container;
-  }
-</style>

--- a/src/lib/components/explorer/ResultInfoComponent.svelte
+++ b/src/lib/components/explorer/ResultInfoComponent.svelte
@@ -2,6 +2,7 @@
   import type { SearchResult } from '$lib/models/Search';
   import { getConceptDetails } from '$lib/stores/Dictionary';
   import Loading from '$lib/components/Loading.svelte';
+  import ShowMoreButton from '$lib/components/buttons/ShowMoreButton.svelte';
   import { branding } from '$lib/configuration';
 
   type InfoRow = {
@@ -83,18 +84,17 @@
 </script>
 
 {#snippet rowContent(row: InfoRow)}
-  <span class="font-bold mb-1" class:capitalize={row.isMeta}>{row.label}:</span>
-  {row.value}
+  <span class="font-bold" class:capitalize={row.isMeta}>{row.label}:</span>
+  <span>{row.value}</span>
 {/snippet}
 
 {#snippet infoRows(rows: InfoRow[])}
-  <div class="w-full flex flex-row flex-wrap justify-between gap-y-1">
+  <div class="w-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-8 gap-y-1">
     {#each rows as row}
-      <div
-        class:w-full={row.layout !== 'top' && !row.isMeta}
-        class:pr-4={row.layout === 'top' || row.isMeta}
-      >
-        {@render rowContent(row)}
+      <div class="min-w-0" class:md:col-span-2={row.layout !== 'top' && !row.isMeta} class:xl:col-span-3={row.layout !== 'top' && !row.isMeta}>
+        <div class="inline-flex gap-1 max-w-full">
+          {@render rowContent(row)}
+        </div>
       </div>
     {/each}
   </div>
@@ -106,57 +106,48 @@
       <Loading ring size="medium" />
     {:then searchResultDetail}
       {@const variableRows = variableInfoRows(searchResultDetail)}
-      <section data-testid="variable-info" class="flex flex-col w-3/4 p-4">
+      <section data-testid="variable-info" class="flex flex-col w-full p-4">
         <h3 class="text-primary-500">
           {branding.explorePage.resultInfo?.variableHeader || 'Variable Information'}
         </h3>
         {@render infoRows(getVisibleRows(variableRows, showAllVariableInfo))}
         {#if variableRows.length > MAX_INFO_ROWS}
-          <button
+          <ShowMoreButton
             data-testid="show-more-variable-info"
-            class="show-more w-fit mx-auto my-1"
+            expanded={showAllVariableInfo}
             onclick={() => (showAllVariableInfo = !showAllVariableInfo)}
-          >
-            {showAllVariableInfo ? 'Show Less' : 'Show More'}
-            <i class="ml-1 fa-solid fa-angle-{showAllVariableInfo ? 'up' : 'down'}"></i>
-          </button>
+          />
         {/if}
       </section>
       {#if searchResultDetail.table}
         {@const datasetRows = datasetInfoRows(searchResultDetail.table)}
-        <section data-testid="dataset-info" class="flex flex-col w-3/4 p-4">
+        <section data-testid="dataset-info" class="flex flex-col w-full p-4">
           <h3 class="text-primary-500">
             {branding.explorePage.resultInfo?.datasetHeader || 'Dataset Information'}
           </h3>
           {@render infoRows(getVisibleRows(datasetRows, showAllDatasetInfo))}
           {#if datasetRows.length > MAX_INFO_ROWS}
-            <button
+            <ShowMoreButton
               data-testid="show-more-dataset-info"
-              class="show-more w-fit mx-auto my-1"
+              expanded={showAllDatasetInfo}
               onclick={() => (showAllDatasetInfo = !showAllDatasetInfo)}
-            >
-              {showAllDatasetInfo ? 'Show Less' : 'Show More'}
-              <i class="ml-1 fa-solid fa-angle-{showAllDatasetInfo ? 'up' : 'down'}"></i>
-            </button>
+            />
           {/if}
         </section>
       {/if}
       {#if searchResultDetail.study}
         {@const studyRows = studyInfoRows(searchResultDetail)}
-        <section data-testid="study-info" class="flex flex-col w-3/4 p-4">
+        <section data-testid="study-info" class="flex flex-col w-full p-4">
           <h3 class="text-primary-500">
             {branding.explorePage.resultInfo?.studyHeader || 'Study Information'}
           </h3>
           {@render infoRows(getVisibleRows(studyRows, showAllStudyInfo))}
           {#if studyRows.length > MAX_INFO_ROWS}
-            <button
+            <ShowMoreButton
               data-testid="show-more-study-info"
-              class="show-more w-fit mx-auto my-1"
+              expanded={showAllStudyInfo}
               onclick={() => (showAllStudyInfo = !showAllStudyInfo)}
-            >
-              {showAllStudyInfo ? 'Show Less' : 'Show More'}
-              <i class="ml-1 fa-solid fa-angle-{showAllStudyInfo ? 'up' : 'down'}"></i>
-            </button>
+            />
           {/if}
         </section>
       {/if}

--- a/src/lib/components/explorer/ResultInfoComponent.svelte
+++ b/src/lib/components/explorer/ResultInfoComponent.svelte
@@ -90,7 +90,10 @@
 {#snippet infoRows(rows: InfoRow[])}
   <div class="w-full flex flex-row flex-wrap justify-between gap-y-1">
     {#each rows as row}
-      <div class:w-full={row.layout !== 'top' && !row.isMeta} class:pr-4={row.layout === 'top' || row.isMeta}>
+      <div
+        class:w-full={row.layout !== 'top' && !row.isMeta}
+        class:pr-4={row.layout === 'top' || row.isMeta}
+      >
         {@render rowContent(row)}
       </div>
     {/each}

--- a/src/lib/components/explorer/ResultInfoComponent.svelte
+++ b/src/lib/components/explorer/ResultInfoComponent.svelte
@@ -2,6 +2,7 @@
   import type { SearchResult } from '$lib/models/Search';
   import { getConceptDetails } from '$lib/stores/Dictionary';
   import Loading from '$lib/components/Loading.svelte';
+  import { branding } from '$lib/configuration';
 
   let { data = {} as SearchResult }: { data?: SearchResult } = $props();
 
@@ -14,7 +15,9 @@
       <Loading ring size="medium" />
     {:then searchResultDetail}
       <section data-testid="variable-info" class="flex flex-col w-3/4 p-4">
-        <h3 class="text-primary-500">Variable Information</h3>
+        <h3 class="text-primary-500">
+          {branding.explorePage.resultInfo?.variableHeader || 'Variable Information'}
+        </h3>
         <div class="w-full flex flex-row justify-between">
           {#if searchResultDetail.display}
             <div><span class="font-bold">Name:</span> {searchResultDetail.display}</div>
@@ -32,7 +35,9 @@
       </section>
       {#if searchResultDetail.table}
         <section data-testid="dataset-info" class="flex flex-col w-3/4 p-4">
-          <h3 class="text-primary-500">Dataset Information</h3>
+          <h3 class="text-primary-500">
+            {branding.explorePage.resultInfo?.datasetHeader || 'Dataset Information'}
+          </h3>
           <div class="w-full flex flex-row justify-between">
             {#if searchResultDetail.table.display}
               <div>
@@ -54,7 +59,9 @@
       {/if}
       {#if searchResultDetail.study}
         <section data-testid="study-info" class="flex flex-col w-3/4 p-4">
-          <h3 class="text-primary-500">Study Information</h3>
+          <h3 class="text-primary-500">
+            {branding.explorePage.resultInfo?.studyHeader || 'Study Information'}
+          </h3>
           <div class="w-full flex flex-col">
             {#if searchResultDetail.study.fullName || searchResultDetail.study.display || searchResultDetail.study.studyAcronym || searchResultDetail?.studyAcronym}
               <div>

--- a/src/lib/components/explorer/ResultInfoComponent.svelte
+++ b/src/lib/components/explorer/ResultInfoComponent.svelte
@@ -91,7 +91,11 @@
 {#snippet infoRows(rows: InfoRow[])}
   <div class="w-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-8 gap-y-1">
     {#each rows as row}
-      <div class="min-w-0" class:md:col-span-2={row.layout !== 'top' && !row.isMeta} class:xl:col-span-3={row.layout !== 'top' && !row.isMeta}>
+      <div
+        class="min-w-0"
+        class:md:col-span-2={row.layout !== 'top' && !row.isMeta}
+        class:xl:col-span-3={row.layout !== 'top' && !row.isMeta}
+      >
         <div class="inline-flex gap-1 max-w-full">
           {@render rowContent(row)}
         </div>

--- a/src/lib/components/explorer/ResultInfoComponent.svelte
+++ b/src/lib/components/explorer/ResultInfoComponent.svelte
@@ -4,81 +4,157 @@
   import Loading from '$lib/components/Loading.svelte';
   import { branding } from '$lib/configuration';
 
+  type InfoRow = {
+    label: string;
+    value: string;
+    isMeta?: boolean;
+    layout?: 'top' | 'stacked';
+  };
+
+  const MAX_INFO_ROWS = 10;
+
   let { data = {} as SearchResult }: { data?: SearchResult } = $props();
 
+  let showAllVariableInfo = $state(false);
+  let showAllDatasetInfo = $state(false);
+  let showAllStudyInfo = $state(false);
+
   let detailPromise = $derived(getConceptDetails(data.conceptPath, data.dataset));
+
+  function isPresent(value: unknown): boolean {
+    return value !== null && value !== undefined && value !== '';
+  }
+
+  function formatValue(value: unknown): string {
+    if (Array.isArray(value)) return value.join(', ');
+    if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+    return String(value);
+  }
+
+  function addRow(
+    rows: InfoRow[],
+    label: string,
+    value: unknown,
+    isMeta = false,
+    layout: InfoRow['layout'] = 'stacked',
+  ): void {
+    if (isPresent(value)) rows.push({ label, value: formatValue(value), isMeta, layout });
+  }
+
+  function getMetaRows(meta: Record<string, unknown> | null | undefined): InfoRow[] {
+    return Object.entries(meta ?? {}).reduce((rows, [label, value]) => {
+      addRow(rows, label, value, true);
+      return rows;
+    }, [] as InfoRow[]);
+  }
+
+  function getVisibleRows(rows: InfoRow[], showAll: boolean): InfoRow[] {
+    return showAll ? rows : rows.slice(0, MAX_INFO_ROWS);
+  }
+
+  function variableInfoRows(searchResultDetail: SearchResult): InfoRow[] {
+    const rows: InfoRow[] = [];
+    addRow(rows, 'Name', searchResultDetail.display, false, 'top');
+    addRow(rows, 'Accession', searchResultDetail.name, false, 'top');
+    addRow(rows, 'Type', searchResultDetail.type, false, 'top');
+    addRow(rows, 'Description', searchResultDetail.description);
+    return [...rows, ...getMetaRows(searchResultDetail.meta)];
+  }
+
+  function datasetInfoRows(table: SearchResult): InfoRow[] {
+    const rows: InfoRow[] = [];
+    addRow(rows, 'Name', table.display, false, 'top');
+    addRow(rows, 'Accession', table.name, false, 'top');
+    addRow(rows, 'Description', table.description);
+    return [...rows, ...getMetaRows(table.meta)];
+  }
+
+  function studyInfoRows(searchResultDetail: SearchResult): InfoRow[] {
+    const rows: InfoRow[] = [];
+    const study = searchResultDetail.study;
+    addRow(
+      rows,
+      'Study Name',
+      study?.fullName || study?.display || study?.studyAcronym || searchResultDetail.studyAcronym,
+    );
+    addRow(rows, 'Study Accession', study?.ref);
+    return [...rows, ...getMetaRows(study?.meta)];
+  }
 </script>
+
+{#snippet rowContent(row: InfoRow)}
+  <span class="font-bold mb-1" class:capitalize={row.isMeta}>{row.label}:</span>
+  {row.value}
+{/snippet}
+
+{#snippet infoRows(rows: InfoRow[])}
+  <div class="w-full flex flex-row flex-wrap justify-between gap-y-1">
+    {#each rows as row}
+      <div class:w-full={row.layout !== 'top' && !row.isMeta} class:pr-4={row.layout === 'top' || row.isMeta}>
+        {@render rowContent(row)}
+      </div>
+    {/each}
+  </div>
+{/snippet}
 
 <div class="card bg-surface-100 min-h-60 p-4">
   <div class="card-body">
     {#await detailPromise}
       <Loading ring size="medium" />
     {:then searchResultDetail}
+      {@const variableRows = variableInfoRows(searchResultDetail)}
       <section data-testid="variable-info" class="flex flex-col w-3/4 p-4">
         <h3 class="text-primary-500">
           {branding.explorePage.resultInfo?.variableHeader || 'Variable Information'}
         </h3>
-        <div class="w-full flex flex-row justify-between">
-          {#if searchResultDetail.display}
-            <div><span class="font-bold">Name:</span> {searchResultDetail.display}</div>
-          {/if}
-          {#if searchResultDetail.name}
-            <div><span class="font-bold mb-1">Accession:</span> {searchResultDetail.name}</div>
-          {/if}
-          {#if searchResultDetail.type}
-            <div><span class="font-bold mb-1">Type:</span> {searchResultDetail.type}</div>
-          {/if}
-        </div>
-        {#if searchResultDetail.description}
-          <div><span class="font-bold">Description:</span> {searchResultDetail.description}</div>
+        {@render infoRows(getVisibleRows(variableRows, showAllVariableInfo))}
+        {#if variableRows.length > MAX_INFO_ROWS}
+          <button
+            data-testid="show-more-variable-info"
+            class="show-more w-fit mx-auto my-1"
+            onclick={() => (showAllVariableInfo = !showAllVariableInfo)}
+          >
+            {showAllVariableInfo ? 'Show Less' : 'Show More'}
+            <i class="ml-1 fa-solid fa-angle-{showAllVariableInfo ? 'up' : 'down'}"></i>
+          </button>
         {/if}
       </section>
       {#if searchResultDetail.table}
+        {@const datasetRows = datasetInfoRows(searchResultDetail.table)}
         <section data-testid="dataset-info" class="flex flex-col w-3/4 p-4">
           <h3 class="text-primary-500">
             {branding.explorePage.resultInfo?.datasetHeader || 'Dataset Information'}
           </h3>
-          <div class="w-full flex flex-row justify-between">
-            {#if searchResultDetail.table.display}
-              <div>
-                <span class="font-bold mb-1">Name:</span>
-                {searchResultDetail.table.display}
-              </div>
-            {/if}
-            {#if searchResultDetail.table.name}
-              <div><span class="font-bold">Accession:</span> {searchResultDetail.table.name}</div>
-            {/if}
-          </div>
-          {#if searchResultDetail.table.description}
-            <div>
-              <span class="font-bold">Description:</span>
-              {searchResultDetail.table.description}
-            </div>
+          {@render infoRows(getVisibleRows(datasetRows, showAllDatasetInfo))}
+          {#if datasetRows.length > MAX_INFO_ROWS}
+            <button
+              data-testid="show-more-dataset-info"
+              class="show-more w-fit mx-auto my-1"
+              onclick={() => (showAllDatasetInfo = !showAllDatasetInfo)}
+            >
+              {showAllDatasetInfo ? 'Show Less' : 'Show More'}
+              <i class="ml-1 fa-solid fa-angle-{showAllDatasetInfo ? 'up' : 'down'}"></i>
+            </button>
           {/if}
         </section>
       {/if}
       {#if searchResultDetail.study}
+        {@const studyRows = studyInfoRows(searchResultDetail)}
         <section data-testid="study-info" class="flex flex-col w-3/4 p-4">
           <h3 class="text-primary-500">
             {branding.explorePage.resultInfo?.studyHeader || 'Study Information'}
           </h3>
-          <div class="w-full flex flex-col">
-            {#if searchResultDetail.study.fullName || searchResultDetail.study.display || searchResultDetail.study.studyAcronym || searchResultDetail?.studyAcronym}
-              <div>
-                <span class="font-bold mb-1">Study Name:</span>
-                {searchResultDetail.study.fullName ||
-                  searchResultDetail.study.display ||
-                  searchResultDetail.study.studyAcronym ||
-                  searchResultDetail?.studyAcronym}
-              </div>
-            {/if}
-            {#if searchResultDetail.study.ref}
-              <div>
-                <span class="font-bold">Study Accession:</span>
-                {searchResultDetail.study.ref}
-              </div>
-            {/if}
-          </div>
+          {@render infoRows(getVisibleRows(studyRows, showAllStudyInfo))}
+          {#if studyRows.length > MAX_INFO_ROWS}
+            <button
+              data-testid="show-more-study-info"
+              class="show-more w-fit mx-auto my-1"
+              onclick={() => (showAllStudyInfo = !showAllStudyInfo)}
+            >
+              {showAllStudyInfo ? 'Show Less' : 'Show More'}
+              <i class="ml-1 fa-solid fa-angle-{showAllStudyInfo ? 'up' : 'down'}"></i>
+            </button>
+          {/if}
         </section>
       {/if}
     {/await}

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -62,6 +62,11 @@ export const branding: Branding = {
   footer: {} as FooterConfig,
   explorePage: {
     tourSearchTerm: import.meta.env?.EXPLORE_TOUR_SEARCH_TERM || 'age',
+    resultInfo: {
+      variableHeader: 'Variable Information',
+      datasetHeader: 'Dataset Information',
+      studyHeader: 'Study Information',
+    },
   } as ExplorePageConfig,
   landing: {} as LandingConfig,
   datasetRequestPage: {} as DatasetRequestPageConfig,

--- a/src/lib/models/Search.ts
+++ b/src/lib/models/Search.ts
@@ -28,9 +28,12 @@ export type SearchResult = Indexable & {
   values?: string[];
   min?: number;
   max?: number;
-  meta?: Record<string, string> | null;
+  meta?: Record<string, unknown> | null;
   table?: SearchResult | null;
   study?: SearchResult | null;
+  fullName?: string;
+  ref?: string;
+  abbreviation?: string;
   type: 'Categorical' | 'Continuous' | 'AnyRecordOf';
   allowFiltering: boolean;
   children?: SearchResult[] | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,11 @@ export interface ExplorePageConfig {
     links: Array<Link>;
   };
   pfbExportUrls?: Link[];
+  resultInfo?: {
+    variableHeader?: string;
+    datasetHeader?: string;
+    studyHeader?: string;
+  };
 }
 
 export interface LandingConfig {

--- a/tests/component/ResultInfoComponent.test.ts
+++ b/tests/component/ResultInfoComponent.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 
 import ResultInfoComponent from '$lib/components/explorer/ResultInfoComponent.svelte';
 import { branding } from '$lib/configuration';
@@ -178,5 +178,72 @@ describe('ResultInfoComponent', () => {
     );
 
     expect(screen.getByTestId('study-info')).toHaveTextContent('Study Name: Root Acronym');
+  });
+
+  it('renders meta key-value pairs in their corresponding sections', async () => {
+    await renderResultInfo(
+      makeDetail({
+        meta: {
+          values: '["0.0","100.0"]',
+          source: 'Variable Source',
+        },
+        table: {
+          ...makeDetail().table,
+          meta: {
+            dataType: 'Dataset Type',
+          },
+        } as SearchResult,
+        study: {
+          ...makeDetail().study,
+          meta: {
+            owner: 'Study Owner',
+          },
+        } as SearchResult,
+      }),
+    );
+
+    expect(screen.getByTestId('variable-info')).toHaveTextContent('values: ["0.0","100.0"]');
+    expect(screen.getByTestId('variable-info')).toHaveTextContent('source: Variable Source');
+    expect(screen.getByTestId('dataset-info')).toHaveTextContent('dataType: Dataset Type');
+    expect(screen.getByTestId('study-info')).toHaveTextContent('owner: Study Owner');
+  });
+
+  it('formats array and object meta values safely', async () => {
+    await renderResultInfo(
+      makeDetail({
+        meta: {
+          arrayValue: ['one', 'two'],
+          objectValue: { nested: 'value' },
+        } as unknown as Record<string, string>,
+      }),
+    );
+
+    expect(screen.getByTestId('variable-info')).toHaveTextContent('arrayValue: one, two');
+    expect(screen.getByTestId('variable-info')).toHaveTextContent(
+      'objectValue: {"nested":"value"}',
+    );
+  });
+
+  it('shows the first 10 total rows and toggles additional meta rows with show more', async () => {
+    await renderResultInfo(
+      makeDetail({
+        meta: Object.fromEntries(
+          Array.from({ length: 7 }, (_, index) => [`meta ${index + 1}`, `value ${index + 1}`]),
+        ),
+      }),
+    );
+
+    const variableInfo = screen.getByTestId('variable-info');
+    expect(variableInfo).toHaveTextContent('Name: Variable Display');
+    expect(variableInfo).toHaveTextContent('meta 6: value 6');
+    expect(variableInfo).not.toHaveTextContent('meta 7: value 7');
+
+    const showMoreButton = screen.getByTestId('show-more-variable-info');
+    expect(showMoreButton).toHaveTextContent('Show More');
+
+    await fireEvent.click(showMoreButton);
+
+    expect(variableInfo).toHaveTextContent('meta 7: value 7');
+    expect(showMoreButton).toHaveTextContent('Show Less');
   });
 });

--- a/tests/component/ResultInfoComponent.test.ts
+++ b/tests/component/ResultInfoComponent.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+import ResultInfoComponent from '$lib/components/explorer/ResultInfoComponent.svelte';
+import { branding } from '$lib/configuration';
+import { getConceptDetails } from '$lib/stores/Dictionary';
+import type { SearchResult } from '$lib/models/Search';
+
+vi.mock('$lib/stores/Dictionary', () => ({
+  getConceptDetails: vi.fn(),
+}));
+
+const mockGetConceptDetails = vi.mocked(getConceptDetails);
+
+const data = {
+  conceptPath: '\\test\\concept\\',
+  dataset: 'dataset-1',
+} as SearchResult;
+
+function makeDetail(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    conceptPath: '\\test\\concept\\',
+    dataset: 'dataset-1',
+    name: 'variable-accession',
+    display: 'Variable Display',
+    studyAcronym: 'Root Study Acronym',
+    description: 'Variable description',
+    type: 'Categorical',
+    allowFiltering: true,
+    table: {
+      conceptPath: '\\test\\table\\',
+      dataset: 'dataset-1',
+      name: 'dataset-accession',
+      display: 'Dataset Display',
+      studyAcronym: '',
+      description: 'Dataset description',
+      type: 'AnyRecordOf',
+      allowFiltering: false,
+    },
+    study: {
+      conceptPath: '\\test\\study\\',
+      dataset: 'dataset-1',
+      name: 'study-name',
+      display: 'Study Display',
+      studyAcronym: 'Study Acronym',
+      fullName: 'Study Full Name',
+      ref: 'study-accession',
+      description: '',
+      type: 'AnyRecordOf',
+      allowFiltering: false,
+    } as SearchResult,
+    ...overrides,
+  };
+}
+
+async function renderResultInfo(detail: SearchResult) {
+  mockGetConceptDetails.mockResolvedValue(detail);
+  render(ResultInfoComponent, { data });
+  await screen.findByTestId('variable-info');
+}
+
+describe('ResultInfoComponent', () => {
+  beforeEach(() => {
+    mockGetConceptDetails.mockReset();
+    branding.explorePage.resultInfo = {
+      variableHeader: 'Variable Information',
+      datasetHeader: 'Dataset Information',
+      studyHeader: 'Study Information',
+    };
+  });
+
+  it('renders configured section headers when the matching sections are present', async () => {
+    branding.explorePage.resultInfo = {
+      variableHeader: 'Custom Variable Header',
+      datasetHeader: 'Custom Dataset Header',
+      studyHeader: 'Custom Study Header',
+    };
+
+    await renderResultInfo(makeDetail());
+
+    expect(screen.getByText('Custom Variable Header')).toBeInTheDocument();
+    expect(screen.getByText('Custom Dataset Header')).toBeInTheDocument();
+    expect(screen.getByText('Custom Study Header')).toBeInTheDocument();
+  });
+
+  it('renders all populated variable, dataset, and study fields', async () => {
+    await renderResultInfo(makeDetail());
+
+    expect(screen.getByTestId('variable-info')).toHaveTextContent('Name: Variable Display');
+    expect(screen.getByTestId('variable-info')).toHaveTextContent('Accession: variable-accession');
+    expect(screen.getByTestId('variable-info')).toHaveTextContent('Type: Categorical');
+    expect(screen.getByTestId('variable-info')).toHaveTextContent(
+      'Description: Variable description',
+    );
+    expect(screen.getByTestId('dataset-info')).toHaveTextContent('Name: Dataset Display');
+    expect(screen.getByTestId('dataset-info')).toHaveTextContent('Accession: dataset-accession');
+    expect(screen.getByTestId('dataset-info')).toHaveTextContent(
+      'Description: Dataset description',
+    );
+    expect(screen.getByTestId('study-info')).toHaveTextContent('Study Name: Study Full Name');
+    expect(screen.getByTestId('study-info')).toHaveTextContent('Study Accession: study-accession');
+  });
+
+  it('does not render dataset or study sections when those objects are missing', async () => {
+    await renderResultInfo(makeDetail({ table: null, study: null }));
+
+    expect(screen.getByTestId('variable-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('dataset-info')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dataset Information')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('study-info')).not.toBeInTheDocument();
+    expect(screen.queryByText('Study Information')).not.toBeInTheDocument();
+  });
+
+  it('does not render field labels for missing values', async () => {
+    await renderResultInfo(
+      makeDetail({
+        display: '',
+        name: '',
+        type: undefined,
+        description: '',
+        table: {
+          ...makeDetail().table,
+          display: '',
+          name: '',
+          description: '',
+        } as SearchResult,
+        study: {
+          ...makeDetail().study,
+          fullName: '',
+          display: '',
+          studyAcronym: '',
+          ref: '',
+        } as SearchResult,
+        studyAcronym: '',
+      } as Partial<SearchResult>),
+    );
+
+    expect(screen.queryByText(/Name:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Accession:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Type:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Description:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Study Name:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Study Accession:/)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [{ fullName: 'Full Name', display: 'Display', studyAcronym: 'Acronym' }, 'Full Name'],
+    [{ fullName: '', display: 'Display', studyAcronym: 'Acronym' }, 'Display'],
+    [{ fullName: '', display: '', studyAcronym: 'Acronym' }, 'Acronym'],
+  ])('renders study name using study fallback %#', async (studyOverrides, expectedStudyName) => {
+    await renderResultInfo(
+      makeDetail({
+        study: {
+          ...makeDetail().study,
+          ...studyOverrides,
+        } as SearchResult,
+      }),
+    );
+
+    expect(screen.getByTestId('study-info')).toHaveTextContent(
+      `Study Name: ${expectedStudyName}`,
+    );
+  });
+
+  it('falls back to the root study acronym when study name fields are missing', async () => {
+    await renderResultInfo(
+      makeDetail({
+        studyAcronym: 'Root Acronym',
+        study: {
+          ...makeDetail().study,
+          fullName: '',
+          display: '',
+          studyAcronym: '',
+        } as SearchResult,
+      }),
+    );
+
+    expect(screen.getByTestId('study-info')).toHaveTextContent('Study Name: Root Acronym');
+  });
+});

--- a/tests/component/ResultInfoComponent.test.ts
+++ b/tests/component/ResultInfoComponent.test.ts
@@ -159,9 +159,7 @@ describe('ResultInfoComponent', () => {
       }),
     );
 
-    expect(screen.getByTestId('study-info')).toHaveTextContent(
-      `Study Name: ${expectedStudyName}`,
-    );
+    expect(screen.getByTestId('study-info')).toHaveTextContent(`Study Name: ${expectedStudyName}`);
   });
 
   it('falls back to the root study acronym when study name fields are missing', async () => {

--- a/tests/component/ShowMoreButton.test.ts
+++ b/tests/component/ShowMoreButton.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import ShowMoreButton from '$lib/components/buttons/ShowMoreButton.svelte';
+
+describe('ShowMoreButton', () => {
+  it('renders the shared show more style and collapsed state', () => {
+    render(ShowMoreButton, {
+      expanded: false,
+      'data-testid': 'toggle-details',
+    });
+
+    const button = screen.getByTestId('toggle-details');
+    const icon = button.querySelector('i');
+
+    expect(button).toHaveTextContent('Show More');
+    expect(button).toHaveClass('show-more', 'w-fit', 'mx-auto', 'my-1');
+    expect(icon).toHaveClass('fa-angle-down');
+  });
+
+  it('renders expanded state and handles clicks', async () => {
+    const onclick = vi.fn();
+
+    render(ShowMoreButton, {
+      expanded: true,
+      onclick,
+      'data-testid': 'toggle-details',
+    });
+
+    const button = screen.getByTestId('toggle-details');
+    const icon = button.querySelector('i');
+
+    expect(button).toHaveTextContent('Show Less');
+    expect(icon).toHaveClass('fa-angle-up');
+
+    await fireEvent.click(button);
+
+    expect(onclick).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/end-to-end/explorer/test.ts
+++ b/tests/end-to-end/explorer/test.ts
@@ -205,31 +205,25 @@ test.describe('Explorer for authenticated users', () => {
         await expect(variableInfo).toBeVisible();
         // Check Variable Information
         await expect(variableInfo.getByText('Variable Information')).toBeVisible();
-        await expect(variableInfo.getByText('Name: ' + detailResponseCat.display)).toBeVisible();
-        await expect(variableInfo.getByText('Accession: ' + detailResponseCat.name)).toBeVisible();
-        await expect(variableInfo.getByText('Type: ' + detailResponseCat.type)).toBeVisible();
-        await expect(
-          variableInfo.getByText('Description: ' + detailResponseCat.description),
-        ).toBeVisible();
+        await expect(variableInfo).toContainText('Name: ' + detailResponseCat.display);
+        await expect(variableInfo).toContainText('Accession: ' + detailResponseCat.name);
+        await expect(variableInfo).toContainText('Type: ' + detailResponseCat.type);
+        await expect(variableInfo).toContainText('Description: ' + detailResponseCat.description);
 
         // Check Dataset Information
-        await expect(infoPanel.getByText('Dataset Information')).toBeVisible();
-        await expect(infoPanel.getByText('Name: ' + detailResponseCat.table.display)).toBeVisible();
-        await expect(
-          infoPanel.getByText('Accession: ' + detailResponseCat.table.name),
-        ).toBeVisible();
-        await expect(
-          infoPanel.getByText('Description: ' + detailResponseCat.table.description),
-        ).toBeVisible();
+        const datasetInfo = infoPanel.getByTestId('dataset-info');
+        await expect(datasetInfo.getByText('Dataset Information')).toBeVisible();
+        await expect(datasetInfo).toContainText('Name: ' + detailResponseCat.table.display);
+        await expect(datasetInfo).toContainText('Accession: ' + detailResponseCat.table.name);
+        await expect(datasetInfo).toContainText(
+          'Description: ' + detailResponseCat.table.description,
+        );
 
         // Check Study Information
-        await expect(infoPanel.getByText('Study Information')).toBeVisible();
-        await expect(
-          infoPanel.getByText('Study Name: ' + detailResponseCat.study.fullName),
-        ).toBeVisible();
-        await expect(
-          infoPanel.getByText('Study Accession: ' + detailResponseCat.study.ref),
-        ).toBeVisible();
+        const studyInfo = infoPanel.getByTestId('study-info');
+        await expect(studyInfo.getByText('Study Information')).toBeVisible();
+        await expect(studyInfo).toContainText('Study Name: ' + detailResponseCat.study.fullName);
+        await expect(studyInfo).toContainText('Study Accession: ' + detailResponseCat.study.ref);
       });
       test('Clicking a filter button opens the filter panel & then clicking another row opens the info panel', async ({
         page,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Show More/Less" toggle button to collapse/expand result information sections, limiting initial display to key fields.
  * Reorganized Variable, Dataset, and Study Information sections with customizable headers for better clarity.
  * Enhanced metadata display to support additional search result fields.

* **Tests**
  * Added test coverage for new components and interactive features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hms-dbmi/PIC-SURE-Frontend/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->