### PR TITLE
[ALS-10714] Consume count/display/variance visualization format

### DIFF
--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -52,7 +52,7 @@
     const plotFilters = get(filters);
     const visualizationFilters = plotFilters.filter(isVisualizationFilter);
     const subtitleByConceptPath = getSubtitleByConceptPath(plotFilters);
-    const minimumCount = isOpenAccess() ? 9 : 1;
+    const minimumCount = 1;
 
     const getSubtitle = (conceptPath?: string) =>
       conceptPath ? subtitleByConceptPath.get(conceptPath) : undefined;

--- a/src/lib/utilities/Plotly.ts
+++ b/src/lib/utilities/Plotly.ts
@@ -2,7 +2,6 @@ import type { PlotlyHTMLElement, Root, Data, Config, Layout } from 'plotly.js-ba
 import { settings } from '$lib/configuration';
 
 const MAX_TITLE_LENGTH = 60;
-const OBFUSCATION_RANGE = 6;
 const defaultColors = settings.distributionExplorer.graphColors;
 
 export const defaultPlotlyConfig: Partial<Config> = {
@@ -29,6 +28,21 @@ export type PlotlyNewPlot = (
   config?: Partial<Config>,
 ) => Promise<PlotlyHTMLElement>;
 
+// One chart value as produced by the visualization resource. The backend owns all
+// obfuscation: count is the bar height, display is the label (e.g. "45000", "222 ±3",
+// "< 10"), and variance (when present) is the half-width of the uncertainty band
+// rendered as [max(0, count - variance), count + variance].
+export type ObfuscatedCount = {
+  count: number;
+  display: string;
+  variance?: number | null;
+};
+
+// Older backends sent plain numbers; normalize them into the rich shape.
+export type CountValue = ObfuscatedCount | number;
+
+type CountMap = { [key: string]: CountValue };
+
 type PlotData = {
   title: string;
   conceptPath?: string;
@@ -37,18 +51,17 @@ type PlotData = {
   colors: string[];
   chartWidth: number;
   chartHeight: number;
-  categoricalMap: { [key: string]: number };
   obfuscated: boolean;
   xaxisName: string;
   yaxisName: string;
 };
 
 export type CategoricalPlotData = PlotData & {
-  categoricalMap: { [key: string]: number };
+  categoricalMap: CountMap;
 };
 
 export type ContinuousPlotData = PlotData & {
-  continuousMap: { [key: string]: number };
+  continuousMap: CountMap;
 };
 
 export type PlotMeta = {
@@ -78,49 +91,42 @@ function shortenTitle(title: string) {
   return title.length > MAX_TITLE_LENGTH ? title.substring(0, MAX_TITLE_LENGTH - 3) + '...' : title;
 }
 
-function obfuscateData(values: number[], obfuscated: boolean) {
-  // shaded area at top of bar chart
-  const topBar: number[] = Array(values.length).fill(OBFUSCATION_RANGE);
-  const bottomBar: string[] = [];
-
-  values.forEach((value, i) => {
-    // If the value is less than 10 and the section obfuscated, then we need to obfuscate the value
-    if (value < 10 && obfuscated) {
-      topBar[i] = 9;
-
-      // Set the text to < 10 so that it shows up in the bar chart
-      bottomBar[i] = '< 10';
-
-      // set the value in the topBar array to 0 so that it doesn't show up in the bar chart
-      values[i] = 0;
-    } else if (obfuscated) {
-      // The value has been obfuscated by +- obfuscationRange
-      bottomBar[i] = value + ' \u00B1 3';
-    } else {
-      topBar[i] = 0;
-      bottomBar[i] = value + '';
-    }
-  });
-  return { topBar, bottomBar };
+export function normalizeCount(value: CountValue): ObfuscatedCount {
+  return typeof value === 'number'
+    ? { count: value, display: String(value), variance: null }
+    : value;
 }
 
-function cutForShading(values: number[], obfuscated: boolean) {
-  return values.map((value) => (obfuscated && value > 0 ? value - OBFUSCATION_RANGE / 2 : value));
+// Split each value into the solid bar and the hatched uncertainty band stacked on
+// top of it. The band spans [max(0, count - variance), count + variance]; exact
+// values (no variance) render as a plain bar with no band.
+function toBars(values: ObfuscatedCount[]) {
+  const solidBar: number[] = [];
+  const hatchedBar: number[] = [];
+  const labels: string[] = [];
+
+  values.forEach(({ count, display, variance }) => {
+    const halfWidth = variance ?? 0;
+    const solid = Math.max(0, count - halfWidth);
+    solidBar.push(solid);
+    hatchedBar.push(count + halfWidth - solid);
+    labels.push(display);
+  });
+  return { solidBar, hatchedBar, labels };
 }
 
 export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
-  const values = Object.values(inData.categoricalMap);
-  const { topBar, bottomBar } = obfuscateData(values, inData.obfuscated);
+  const keys = Object.keys(inData.categoricalMap);
+  const values = Object.values(inData.categoricalMap).map(normalizeCount);
+  const { solidBar, hatchedBar, labels } = toBars(values);
 
   const colors: string[] = getColors(values.length);
   const title = shortenTitle(inData.title);
   const subtitle = getSubTitle(inData);
   const data: Data[] = [
     {
-      x: Object.keys(inData.categoricalMap),
-      // Remove half of the obfuscation range value from the top of the bar
-      // chart to make room for the shaded area
-      y: cutForShading(values, inData.obfuscated),
+      x: keys,
+      y: solidBar,
       name: title,
       type: 'bar',
       showlegend: false,
@@ -129,9 +135,9 @@ export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
       },
     },
     {
-      // Shaded portion
-      x: Object.keys(inData.categoricalMap),
-      y: topBar,
+      // Hatched uncertainty band stacked on the solid bar
+      x: keys,
+      y: hatchedBar,
       name: 'Obfuscated Data',
       showlegend: false,
       type: 'bar',
@@ -143,7 +149,7 @@ export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
           solidity: 0.5,
         },
       },
-      text: bottomBar,
+      text: labels,
       textposition: 'outside',
     },
   ];
@@ -187,8 +193,6 @@ export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
 }
 
 export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
-  const isObfuscated = inData.obfuscated;
-
   /*
    * The dataMap.continuousMap is an object with the key being the range and the value being the count.
    * When converting the keys, which are a string of the range, to an array of numbers, we are not
@@ -199,7 +203,7 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
    * This doesn't happen when the data isn't obfuscated because the keys are the same as the values.
    */
   const orderedKeys: string[] = [];
-  const orderedValues: number[] = [];
+  const orderedValues: ObfuscatedCount[] = [];
   Object.keys(inData.continuousMap)
     .sort((a, b) => {
       // sort the keys by the lower limit of the range
@@ -214,16 +218,16 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
     })
     .forEach((key) => {
       orderedKeys.push(key);
-      orderedValues.push(inData.continuousMap[key]);
+      orderedValues.push(normalizeCount(inData.continuousMap[key]));
     });
 
-  const { topBar, bottomBar } = obfuscateData(orderedValues, isObfuscated);
+  const { solidBar, hatchedBar, labels } = toBars(orderedValues);
   const title = shortenTitle(inData.title);
   const subtitle = getSubTitle(inData);
   const data: Data[] = [
     {
       x: orderedKeys,
-      y: cutForShading(orderedValues, inData.obfuscated),
+      y: solidBar,
       name: title,
       type: 'bar',
       showlegend: false,
@@ -236,8 +240,9 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
       },
     },
     {
+      // Hatched uncertainty band stacked on the solid bar
       x: orderedKeys,
-      y: topBar,
+      y: hatchedBar,
       name: 'Obfuscated Data',
       showlegend: false,
       type: 'bar',
@@ -253,7 +258,7 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
           width: 1,
         },
       },
-      text: bottomBar,
+      text: labels,
       textposition: 'outside',
     },
   ];

--- a/src/lib/utilities/Plotly.ts
+++ b/src/lib/utilities/Plotly.ts
@@ -28,17 +28,13 @@ export type PlotlyNewPlot = (
   config?: Partial<Config>,
 ) => Promise<PlotlyHTMLElement>;
 
-// One chart value as produced by the visualization resource. The backend owns all
-// obfuscation: count is the bar height, display is the label (e.g. "45000", "222 ±3",
-// "< 10"), and variance (when present) is the half-width of the uncertainty band
-// rendered as [max(0, count - variance), count + variance].
 export type ObfuscatedCount = {
   count: number;
   display: string;
   variance?: number | null;
 };
 
-// Older backends sent plain numbers; normalize them into the rich shape.
+// For backwards compatibility
 export type CountValue = ObfuscatedCount | number;
 
 type CountMap = { [key: string]: CountValue };
@@ -97,9 +93,6 @@ export function normalizeCount(value: CountValue): ObfuscatedCount {
     : value;
 }
 
-// Split each value into the solid bar and the hatched uncertainty band stacked on
-// top of it. The band spans [max(0, count - variance), count + variance]; exact
-// values (no variance) render as a plain bar with no band.
 function toBars(values: ObfuscatedCount[]) {
   const solidBar: number[] = [];
   const hatchedBar: number[] = [];
@@ -193,15 +186,6 @@ export function createCategoryPlot(inData: CategoricalPlotData): PlotValues {
 }
 
 export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
-  /*
-   * The dataMap.continuousMap is an object with the key being the range and the value being the count.
-   * When converting the keys, which are a string of the range, to an array of numbers, we are not
-   * guaranteed that the keys will be in order. We need to sort the keys by the lower limit of the range.
-   * If the lower limit is NaN, then it is a single value. We need to sort the keys by the lower limit of
-   * the range.
-   *
-   * This doesn't happen when the data isn't obfuscated because the keys are the same as the values.
-   */
   const orderedKeys: string[] = [];
   const orderedValues: ObfuscatedCount[] = [];
   Object.keys(inData.continuousMap)
@@ -212,7 +196,7 @@ export function createContinuousPlot(inData: ContinuousPlotData): PlotValues {
 
       // If the lower limit is NaN, then it is a single value
       if (isNaN(aLowerLimit)) aLowerLimit = parseFloat(a.split(' +')[0]);
-      if (isNaN(bLowerLimit)) bLowerLimit = parseFloat(a.split(' +')[0]);
+      if (isNaN(bLowerLimit)) bLowerLimit = parseFloat(b.split(' +')[0]);
 
       return aLowerLimit - bLowerLimit;
     })

--- a/src/lib/utilities/VisualizationData.ts
+++ b/src/lib/utilities/VisualizationData.ts
@@ -19,9 +19,8 @@ export function visualizationVariableLabel(filter: Filter) {
   return study ? `${study} - ${label}` : label;
 }
 
-// Sums the upper bound of each value's uncertainty band (count + variance), so a chart
-// whose only bucket is "< 10" (count 0, variance 9) still counts as potentially having
-// data. Plain-number values from older backends are normalized to exact counts.
+// Sums each value's band upper bound (count + variance) so a chart whose only
+// bucket is "< 10" (count 0, variance 9) still counts as having data
 export function totalMapCount(map?: Record<string, CountValue>) {
   return Object.values(map || {}).reduce((total: number, value) => {
     const { count, variance } = normalizeCount(value);

--- a/src/lib/utilities/VisualizationData.ts
+++ b/src/lib/utilities/VisualizationData.ts
@@ -1,4 +1,9 @@
-import type { CategoricalPlotData, ContinuousPlotData } from '$lib/utilities/Plotly';
+import {
+  normalizeCount,
+  type CategoricalPlotData,
+  type ContinuousPlotData,
+  type CountValue,
+} from '$lib/utilities/Plotly';
 import type { Filter } from '$lib/models/Filter.svelte';
 
 export type VisualizationPlotData = CategoricalPlotData | ContinuousPlotData;
@@ -14,8 +19,14 @@ export function visualizationVariableLabel(filter: Filter) {
   return study ? `${study} - ${label}` : label;
 }
 
-export function totalMapCount(map?: Record<string, number>) {
-  return Object.values(map || {}).reduce((total, value) => total + Number(value || 0), 0);
+// Sums the upper bound of each value's uncertainty band (count + variance), so a chart
+// whose only bucket is "< 10" (count 0, variance 9) still counts as potentially having
+// data. Plain-number values from older backends are normalized to exact counts.
+export function totalMapCount(map?: Record<string, CountValue>) {
+  return Object.values(map || {}).reduce((total: number, value) => {
+    const { count, variance } = normalizeCount(value);
+    return total + count + (variance ?? 0);
+  }, 0);
 }
 
 export function categoricalHasData(data: CategoricalPlotData, minimumCount: number) {

--- a/tests/end-to-end/discover/distributions/test.ts
+++ b/tests/end-to-end/discover/distributions/test.ts
@@ -1,0 +1,79 @@
+import { expect } from '@playwright/test';
+import { test, mockApiSuccess } from '../../custom-context';
+import {
+  facetResultPath,
+  facetsResponse,
+  searchResultPath,
+  searchResults as mockData,
+  crossCountSyncResponseInital,
+} from '../../mock-data';
+
+const distributionsPath = '*/**/picsure/proxy/visualization/distributions';
+const openCountResultPath = '*/**/picsure/query/sync';
+
+// Visualization resource response in the {count, display, variance} wire shape:
+// exact values carry a null variance, randomized values carry the configured
+// variance, and below-threshold values are encoded as count 0 / variance threshold-1.
+const distributionsResponse = {
+  categoricalData: [
+    {
+      conceptPath: '\\demographics\\race\\',
+      title: 'demographics: race',
+      continuous: false,
+      categoricalMap: {
+        White: { count: 45000, display: '45000 ±3', variance: 3 },
+        Black: { count: 12000, display: '12000', variance: null },
+        Other: { count: 0, display: '< 10', variance: 9 },
+      },
+      obfuscated: true,
+      xaxisName: 'race',
+      yaxisName: 'Number of Participants',
+      chartWidth: 500,
+      chartHeight: 600,
+    },
+  ],
+  continuousData: [
+    {
+      conceptPath: '\\measurements\\bmi\\',
+      title: 'measurements: bmi',
+      continuous: true,
+      continuousMap: {
+        '18.0 - 24.0': { count: 600, display: '600 ±3', variance: 3 },
+        '24.0 - 30.0': { count: 0, display: '< 10', variance: 9 },
+        '30.0 +': { count: 150, display: '150 ±3', variance: 3 },
+      },
+      obfuscated: true,
+      xaxisName: 'bmi',
+      yaxisName: 'Number of Participants',
+      chartWidth: 500,
+      chartHeight: 600,
+    },
+  ],
+};
+
+test.use({ storageState: 'tests/end-to-end/.auth/unauthenticated.json' });
+
+test.describe('Discover distributions', () => {
+  test('renders charts with backend-provided count, display, and variance', async ({ page }) => {
+    // Given: the visualization endpoint returns the new wire shape
+    await mockApiSuccess(page, searchResultPath, mockData);
+    await mockApiSuccess(page, facetResultPath, facetsResponse);
+    await mockApiSuccess(page, '*/**/picsure/search/2', crossCountSyncResponseInital);
+    await mockApiSuccess(page, openCountResultPath, '9999');
+    await mockApiSuccess(page, distributionsPath, distributionsResponse);
+
+    // When: opening the distributions page
+    await page.goto('/discover/distributions');
+
+    // Then: one categorical and one continuous plot render
+    const visualizations = page.locator('#visualizations');
+    await expect(page.locator('#plot-0')).toBeVisible();
+    await expect(page.locator('#plot-1')).toBeVisible();
+
+    // And the bar labels come straight from the backend display strings
+    await expect(visualizations).toContainText('< 10');
+    await expect(visualizations).toContainText('45000 ±3');
+    await expect(visualizations).toContainText('12000');
+    await expect(visualizations).toContainText('600 ±3');
+  });
+});

--- a/tests/unit/Plotly.test.ts
+++ b/tests/unit/Plotly.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('$lib/configuration', () => ({
+  settings: { distributionExplorer: { graphColors: ['#111111', '#222222'] } },
+}));
+
+import {
+  createCategoryPlot,
+  createContinuousPlot,
+  type CategoricalPlotData,
+  type ContinuousPlotData,
+} from '$lib/utilities/Plotly';
+
+const baseChart = {
+  title: 'demographics: race',
+  continuous: false,
+  colors: [],
+  chartWidth: 500,
+  chartHeight: 600,
+  xaxisName: 'race',
+  yaxisName: 'Number of Participants',
+};
+
+type BarTrace = { x: string[]; y: number[]; text?: string[] };
+
+function categoricalPlot(map: CategoricalPlotData['categoricalMap'], obfuscated = false) {
+  const plot = createCategoryPlot({
+    ...baseChart,
+    obfuscated,
+    categoricalMap: map,
+  } as CategoricalPlotData);
+  const [solid, hatched] = plot.data as unknown as [BarTrace, BarTrace];
+  return { plot, solid, hatched };
+}
+
+describe('createCategoryPlot', () => {
+  it('renders exact (authorized) values as plain bars with no uncertainty band', () => {
+    const { solid, hatched } = categoricalPlot({
+      White: { count: 45000, display: '45000', variance: null },
+      Black: { count: 12000, display: '12000', variance: null },
+    });
+
+    expect(solid.y).toEqual([45000, 12000]);
+    expect(hatched.y).toEqual([0, 0]);
+    expect(hatched.text).toEqual(['45000', '12000']);
+  });
+
+  it('renders variance values with a band spanning count ± variance', () => {
+    const { solid, hatched } = categoricalPlot(
+      { White: { count: 222, display: '222 ±3', variance: 3 } },
+      true,
+    );
+
+    // Solid bar to count - variance, band of 2 * variance on top (top of stack = count + variance)
+    expect(solid.y).toEqual([219]);
+    expect(hatched.y).toEqual([6]);
+    expect(hatched.text).toEqual(['222 ±3']);
+  });
+
+  it('renders below-threshold values as a fully hatched bar up to the threshold band', () => {
+    const { solid, hatched } = categoricalPlot(
+      { Other: { count: 0, display: '< 10', variance: 9 } },
+      true,
+    );
+
+    expect(solid.y).toEqual([0]);
+    expect(hatched.y).toEqual([9]);
+    expect(hatched.text).toEqual(['< 10']);
+  });
+
+  it('clamps the band at zero when variance exceeds count', () => {
+    const { solid, hatched } = categoricalPlot(
+      { Rare: { count: 2, display: '2 ±3', variance: 3 } },
+      true,
+    );
+
+    expect(solid.y).toEqual([0]);
+    // Band runs from 0 to count + variance
+    expect(hatched.y).toEqual([5]);
+  });
+
+  it('normalizes legacy plain-number values into exact bars', () => {
+    const { solid, hatched } = categoricalPlot({ White: 45000, Black: 12000 });
+
+    expect(solid.y).toEqual([45000, 12000]);
+    expect(hatched.y).toEqual([0, 0]);
+    expect(hatched.text).toEqual(['45000', '12000']);
+  });
+});
+
+describe('createContinuousPlot', () => {
+  function continuousPlot(map: ContinuousPlotData['continuousMap'], obfuscated = false) {
+    const plot = createContinuousPlot({
+      ...baseChart,
+      title: 'measurements: bmi',
+      continuous: true,
+      obfuscated,
+      continuousMap: map,
+    } as ContinuousPlotData);
+    const [solid, hatched] = plot.data as unknown as [BarTrace, BarTrace];
+    return { plot, solid, hatched };
+  }
+
+  it('orders bins by their lower limit and renders counts and labels', () => {
+    const { solid, hatched } = continuousPlot({
+      '30.0 +': { count: 150, display: '150 ±3', variance: 3 },
+      '18.0 - 24.0': { count: 600, display: '600 ±3', variance: 3 },
+      '24.0 - 30.0': { count: 0, display: '< 10', variance: 9 },
+    });
+
+    expect(solid.x).toEqual(['18.0 - 24.0', '24.0 - 30.0', '30.0 +']);
+    expect(solid.y).toEqual([597, 0, 147]);
+    expect(hatched.y).toEqual([6, 9, 6]);
+    expect(hatched.text).toEqual(['600 ±3', '< 10', '150 ±3']);
+  });
+
+  it('normalizes legacy plain-number values', () => {
+    const { solid, hatched } = continuousPlot({
+      '18.0 - 24.0': 600,
+      '24.0 - 30.0': 700,
+    });
+
+    expect(solid.y).toEqual([600, 700]);
+    expect(hatched.y).toEqual([0, 0]);
+    expect(hatched.text).toEqual(['600', '700']);
+  });
+});

--- a/tests/unit/VisualizationData.test.ts
+++ b/tests/unit/VisualizationData.test.ts
@@ -7,14 +7,14 @@ import {
   isVisualizationFilter,
   visualizationVariableLabel,
 } from '$lib/utilities/VisualizationData';
-import type { CategoricalPlotData, ContinuousPlotData } from '$lib/utilities/Plotly';
+import type { CategoricalPlotData, ContinuousPlotData, CountValue } from '$lib/utilities/Plotly';
 import type { Filter } from '$lib/models/Filter.svelte';
 
-function categorical(conceptPath: string | undefined, categoricalMap: Record<string, number>) {
+function categorical(conceptPath: string | undefined, categoricalMap: Record<string, CountValue>) {
   return { conceptPath, categoricalMap } as CategoricalPlotData;
 }
 
-function continuous(conceptPath: string | undefined, continuousMap: Record<string, number>) {
+function continuous(conceptPath: string | undefined, continuousMap: Record<string, CountValue>) {
   return { conceptPath, continuousMap } as ContinuousPlotData;
 }
 
@@ -44,6 +44,34 @@ describe('VisualizationData', () => {
     expect(categoricalHasData(categorical('cat', { Yes: 8 }), 9)).toBe(false);
     expect(continuousHasData(continuous('con', { '0 - 10': 9 }), 9)).toBe(true);
     expect(continuousHasData(continuous('con', { '0 - 10': 8 }), 9)).toBe(false);
+  });
+
+  it('sums the band upper bound of {count, display, variance} values', () => {
+    // A chart whose only bucket is below-threshold (count 0, variance 9) may still have data
+    expect(
+      categoricalHasData(
+        categorical('cat', { Other: { count: 0, display: '< 10', variance: 9 } }),
+        9,
+      ),
+    ).toBe(true);
+    expect(
+      categoricalHasData(
+        categorical('cat', { Yes: { count: 12000, display: '12000', variance: null } }),
+        9,
+      ),
+    ).toBe(true);
+    expect(
+      categoricalHasData(
+        categorical('cat', { Yes: { count: 0, display: '0', variance: null } }),
+        1,
+      ),
+    ).toBe(false);
+    expect(
+      continuousHasData(
+        continuous('con', { '0 - 10': { count: 222, display: '222 ±3', variance: 3 } }),
+        9,
+      ),
+    ).toBe(true);
   });
 
   it('excludes selected visualization filters missing from graphable response data', () => {


### PR DESCRIPTION
Removes the frontend's own obfuscation logic (obfuscateData, cutForShading, OBFUSCATION_RANGE) — the backend now owns all obfuscation. Charts render bars from count, label them with the backend's display string, and draw the hatched uncertainty band as [max(0, count − variance), count + variance], reproducing the previous visuals exactly. totalMapCount sums the band's upper bound so all-below-threshold charts still display. Plain-number values from older backends are normalized to exact counts. Adds unit tests for the plot transforms and an e2e test against a mocked distributions endpoint.