### PR TITLE
[ALS-11935] Track page_views on client-side navigation

### DIFF
--- a/src/lib/components/tracking/GoogleTracking.svelte
+++ b/src/lib/components/tracking/GoogleTracking.svelte
@@ -95,15 +95,9 @@
       // applies for this session via the consent update below.
     }
 
-    // gtag.js is already loaded (initialized on mount); send a consent update
-    // rather than re-initializing, which would inject duplicate scripts.
     gtag('consent', 'update', consent);
   }
 
-  // Read persisted consent, failing safe to deny-all on malformed JSON, blocked
-  // storage access (sandbox/private mode), or a non-object value. Returns null
-  // when no valid consent is stored, so the prompt is (re)shown. This component
-  // renders in the root layout, so an unhandled throw here would break hydration.
   function loadConsent(): Consent | null {
     try {
       const stored = localStorage.getItem('consentMode');
@@ -121,9 +115,6 @@
     const storedConsent = loadConsent();
     consent = storedConsent ?? defaultConsent;
 
-    // Always initialize tracking on load. Consent Mode (set inside initialize)
-    // governs granted/denied behavior; gating this on the prompt previously
-    // disabled analytics entirely whenever the prompt was not shown.
     initialize();
 
     if (enablePrompt) {

--- a/src/lib/components/tracking/GoogleTracking.svelte
+++ b/src/lib/components/tracking/GoogleTracking.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
   import { page } from '$app/state';
   import { branding, settings } from '$lib/configuration';
   import { log, createLog } from '$lib/logger';
@@ -130,6 +131,20 @@
     if (enablePrompt) {
       consentPrompt = storedConsent === null;
     }
+  });
+
+  // Send a page_view on each SvelteKit client-side navigation. initialize() only
+  // fires once on mount, so without this only the initial document load (and the
+  // server redirects to /explorer and /discover) reach GA — SPA navigations are
+  // never tracked. Skip the initial 'enter' navigation, already counted by the
+  // gtag('config', ...) call in initialize().
+  afterNavigate((navigation) => {
+    if (navigation.type === 'enter' || !googleAnalyticsID) return;
+    gtag('event', 'page_view', {
+      page_title: document.title,
+      page_path: page.url.pathname,
+      page_location: page.url.href,
+    });
   });
 </script>
 

--- a/src/lib/components/tracking/GoogleTracking.svelte
+++ b/src/lib/components/tracking/GoogleTracking.svelte
@@ -126,18 +126,11 @@
     // disabled analytics entirely whenever the prompt was not shown.
     initialize();
 
-    // Open the consent prompt only when a privacy policy is configured and the
-    // user has not yet made (or no longer has) a valid stored choice.
     if (enablePrompt) {
       consentPrompt = storedConsent === null;
     }
   });
 
-  // Send a page_view on each SvelteKit client-side navigation. initialize() only
-  // fires once on mount, so without this only the initial document load (and the
-  // server redirects to /explorer and /discover) reach GA — SPA navigations are
-  // never tracked. Skip the initial 'enter' navigation, already counted by the
-  // gtag('config', ...) call in initialize().
   afterNavigate((navigation) => {
     if (navigation.type === 'enter' || !googleAnalyticsID) return;
     gtag('event', 'page_view', {

--- a/tests/component/GoogleTracking.test.ts
+++ b/tests/component/GoogleTracking.test.ts
@@ -7,6 +7,19 @@ vi.mock('$app/state', () => ({
   page: { url: new URL('http://localhost/explorer') },
 }));
 
+// Capture the afterNavigate callback the component registers so tests can fire
+// navigations. The holder is created via vi.hoisted so the hoisted vi.mock
+// factory below can reference it.
+const navigation = vi.hoisted(() => ({
+  cb: undefined as ((nav: { type: string }) => void) | undefined,
+}));
+
+vi.mock('$app/navigation', () => ({
+  afterNavigate: (cb: (nav: { type: string }) => void) => {
+    navigation.cb = cb;
+  },
+}));
+
 // Analytics-only configuration (no tag manager) — also guards the regression
 // where the consent prompt was coupled to `tagManager` being set. The literal
 // must be inlined here because vi.mock factories are hoisted above module vars.
@@ -22,8 +35,18 @@ vi.mock('$lib/logger', () => ({
 }));
 
 import GoogleTracking from '$lib/components/tracking/GoogleTracking.svelte';
+import { page } from '$app/state';
 
 const ANALYTICS_ID = 'G-TEST123';
+
+// page.url is readonly on the real type; cast to mutate the mock between navigations.
+function setRoute(pathname: string) {
+  (page as unknown as { url: URL }).url = new URL(`http://localhost${pathname}`);
+}
+
+function pageViewEvents(): Command[] {
+  return dataLayer().filter((e) => e[0] === 'event' && e[1] === 'page_view');
+}
 
 type Command = IArguments & Record<number, unknown>;
 
@@ -146,5 +169,31 @@ describe('GoogleTracking', () => {
     const update = findCommand('consent', 'update');
     expect(update, 'expected a consent update even when persistence fails').toBeDefined();
     expect(update?.[2]).toMatchObject({ analytics_storage: 'granted' });
+  });
+
+  it('sends a page_view on client-side navigation (regression: SPA nav untracked)', () => {
+    setRoute('/explorer');
+    render(GoogleTracking);
+
+    // Initial load is tracked via gtag('config', …); no page_view event yet.
+    expect(pageViewEvents().length).toBe(0);
+
+    // Navigate client-side to a new route and let SvelteKit complete it.
+    setRoute('/dataset/42');
+    navigation.cb?.({ type: 'goto' });
+
+    const events = pageViewEvents();
+    expect(events.length).toBe(1);
+    expect(events[0][2]).toMatchObject({ page_path: '/dataset/42' });
+  });
+
+  it('does not double-count the initial load (skips the "enter" navigation)', () => {
+    setRoute('/explorer');
+    render(GoogleTracking);
+
+    // 'enter' is the initial mount, already counted by gtag('config', …).
+    navigation.cb?.({ type: 'enter' });
+
+    expect(pageViewEvents().length).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Google Analytics tracking to properly record page view events during in-app navigation, ensuring accurate tracking beyond the initial page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->