### PR TITLE
[ALS-12024] Fix Dataset Restore Issues

### DIFF
--- a/src/lib/components/query/QueryConverters.ts
+++ b/src/lib/components/query/QueryConverters.ts
@@ -84,10 +84,12 @@ export function estimateV2(query: QueryV2): QueryEstimate {
 
 export function queryV2ToV3(query: QueryV2): QueryV3 {
   const clauses: PhenotypicFilterInterface[] = [];
+  const exportSystemFields = features.explorer.exportSystemFields || [];
 
   for (const [conceptPath, values] of Object.entries(
     query.categoryFilters as Record<string, string[]>,
   )) {
+    if (exportSystemFields.includes(conceptPath)) continue;
     clauses.push({
       type: 'PhenotypicFilter',
       phenotypicFilterType: 'FILTER',

--- a/src/lib/components/query/QueryConverters.ts
+++ b/src/lib/components/query/QueryConverters.ts
@@ -1,3 +1,4 @@
+import { features } from '$lib/configuration';
 import {
   QueryV2,
   QueryV3,
@@ -316,6 +317,10 @@ export type QuerySummaryData = {
 export function loadQuerySummaryData(query: QueryV2 | QueryV3, version: string): QuerySummaryData {
   const q: QueryV3 =
     version === QueryVersion.V3 ? (query as QueryV3) : queryV2ToV3(query as QueryV2);
+
+  const exportSystemFields = features.explorer.exportSystemFields || [];
+  if (exportSystemFields.length > 0)
+    q.select = q.select.filter((select: string) => !exportSystemFields.includes(select));
 
   const errorsList: string[] = [];
   const filterTree = queryToFilterTree(q, errorsList);

--- a/src/lib/models/Dataset.ts
+++ b/src/lib/models/Dataset.ts
@@ -50,6 +50,26 @@ function getQueryVersion(query: string) {
   else return QueryVersion.UNKNOWN;
 }
 
+/**
+ * True if `value` is a string that is itself JSON-encoding an object/array —
+ * i.e. it's been through an extra JSON.stringify() and needs one more parse.
+ * A string that merely parses to a JSON primitive (a number, boolean, null,
+ * or quoted string) does NOT count — only object/array results indicate a
+ * real extra layer of nesting.
+ */
+function isDoubleEncoded(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return false; // not valid JSON at all -> not double-encoded
+  }
+
+  return parsed !== null && typeof parsed === 'object';
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function mapDataset(data: any) {
   let federated;
@@ -59,10 +79,11 @@ export function mapDataset(data: any) {
   else {
     try {
       const jsonQuery = JSON.parse(data.query.query);
+      const subquery = isDoubleEncoded(jsonQuery.query)
+        ? JSON.parse(jsonQuery.query)
+        : jsonQuery.query;
       query =
-        version === QueryVersion.V2
-          ? new QueryV2(jsonQuery.query)
-          : QueryV3.fromSerialized(jsonQuery.query);
+        version === QueryVersion.V2 ? new QueryV2(subquery) : QueryV3.fromSerialized(subquery);
       if (jsonQuery?.commonAreaUUID) {
         federated = {
           commonId: jsonQuery?.commonAreaUUID,

--- a/tests/unit/Dataset.test.ts
+++ b/tests/unit/Dataset.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+
+import { mapDataset, QueryVersion } from '$lib/models/Dataset';
+import { QueryV2, QueryV3 } from '$lib/models/query/Query';
+
+const V2_INNER_QUERY = {
+  categoryFilters: { '\\\\dataset\\\\sex\\\\': ['Male'] },
+  fields: ['\\\\dataset\\\\age\\\\'],
+};
+
+const V3_INNER_QUERY = {
+  phenotypicClause: {
+    type: 'PhenotypicFilter',
+    phenotypicFilterType: 'FILTER',
+    conceptPath: '\\\\dataset\\\\sex\\\\',
+    not: false,
+    values: ['Male'],
+  },
+  select: ['\\\\dataset\\\\age\\\\'],
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeData(rawQuery: string, overrides: Partial<Record<string, any>> = {}) {
+  return {
+    uuid: 'dataset-uuid',
+    user: 'test-user',
+    name: 'Test Dataset',
+    archived: false,
+    metadata: {},
+    query: {
+      query: rawQuery,
+      uuid: 'query-uuid',
+      startTime: 1690000000000,
+      status: 'COMPLETE',
+    },
+    ...overrides,
+  };
+}
+
+// Simulates the normal case: query.query.query is a plain object nested inside the outer JSON string.
+function singleEncode(innerQuery: object, extra: object = {}) {
+  return JSON.stringify({ query: innerQuery, ...extra });
+}
+
+// Simulates the bug case: query.query.query has been JSON.stringify'd an extra time,
+// so `jsonQuery.query` is itself a JSON-encoded string rather than an object.
+function doubleEncode(innerQuery: object, extra: object = {}) {
+  return JSON.stringify({ query: JSON.stringify(innerQuery), ...extra });
+}
+
+describe('mapDataset', () => {
+  describe('single-encoded query.query.query (normal path)', () => {
+    it('maps a V2 query', () => {
+      // Given
+      const data = makeData(singleEncode(V2_INNER_QUERY));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.version).toBe(QueryVersion.V2);
+      expect(dataset.query).toBeInstanceOf(QueryV2);
+      const query = dataset.query as QueryV2;
+      expect(query.categoryFilters).toEqual(V2_INNER_QUERY.categoryFilters);
+      expect(query.fields).toEqual(V2_INNER_QUERY.fields);
+    });
+
+    it('maps a V3 query', () => {
+      // Given
+      const data = makeData(singleEncode(V3_INNER_QUERY));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.version).toBe(QueryVersion.V3);
+      expect(dataset.query).toBeInstanceOf(QueryV3);
+      const query = dataset.query as QueryV3;
+      expect(query.select).toEqual(V3_INNER_QUERY.select);
+      expect(query.phenotypicClause).toMatchObject({
+        type: 'PhenotypicFilter',
+        conceptPath: '\\\\dataset\\\\sex\\\\',
+        values: ['Male'],
+      });
+    });
+  });
+
+  describe('double-encoded query.query.query (extra JSON.stringify layer)', () => {
+    it('maps a V2 query', () => {
+      // This path is unlikely, but may as well test it
+      // Given
+      const data = makeData(doubleEncode(V2_INNER_QUERY));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.version).toBe(QueryVersion.V2);
+      expect(dataset.query).toBeInstanceOf(QueryV2);
+      const query = dataset.query as QueryV2;
+      expect(query.categoryFilters).toEqual(V2_INNER_QUERY.categoryFilters);
+      expect(query.fields).toEqual(V2_INNER_QUERY.fields);
+    });
+
+    it('maps a V3 query', () => {
+      // Given
+      const data = makeData(doubleEncode(V3_INNER_QUERY));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.version).toBe(QueryVersion.V3);
+      expect(dataset.query).toBeInstanceOf(QueryV3);
+      const query = dataset.query as QueryV3;
+      expect(query.select).toEqual(V3_INNER_QUERY.select);
+      expect(query.phenotypicClause).toMatchObject({
+        type: 'PhenotypicFilter',
+        conceptPath: '\\\\dataset\\\\sex\\\\',
+        values: ['Male'],
+      });
+    });
+  });
+
+  describe('federated commonAreaUUID', () => {
+    // these paths are also unlikely, but may as well test them
+    it('sets federated.commonId when single-encoded', () => {
+      // Given
+      const data = makeData(singleEncode(V2_INNER_QUERY, { commonAreaUUID: 'common-area-uuid' }));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.federated).toEqual({ commonId: 'common-area-uuid' });
+    });
+
+    it('sets federated.commonId when double-encoded', () => {
+      // Given
+      const data = makeData(doubleEncode(V2_INNER_QUERY, { commonAreaUUID: 'common-area-uuid' }));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.federated).toEqual({ commonId: 'common-area-uuid' });
+    });
+
+    it('leaves federated undefined when commonAreaUUID is absent', () => {
+      // Given
+      const data = makeData(singleEncode(V2_INNER_QUERY));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.federated).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns a null query when the version cannot be determined', () => {
+      // Given
+      const data = makeData(JSON.stringify({ query: { unrelatedField: true } }));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.version).toBe(QueryVersion.UNKNOWN);
+      expect(dataset.query).toBeNull();
+    });
+
+    it('returns a null query when query.query.query is not valid JSON', () => {
+      // Given — string still contains 'categoryFilters' so version detection succeeds,
+      // but the outer JSON.parse itself fails
+      const data = makeData('{not valid json, categoryFilters');
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.query).toBeNull();
+    });
+
+    it('does not treat a plain string value of query.query.query.query as double-encoded', () => {
+      // Given — jsonQuery.query parses to a JSON string primitive ("foo"), not an object,
+      // so it should be left as-is rather than parsed again
+      const data = makeData(JSON.stringify({ query: '"categoryFilters-marker"' }));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then — falls through to QueryV2 constructor with a string, which yields defaults
+      expect(dataset.version).toBe(QueryVersion.V2);
+      expect(dataset.query).toBeInstanceOf(QueryV2);
+      expect((dataset.query as QueryV2).categoryFilters).toEqual({});
+    });
+  });
+
+  describe('other fields', () => {
+    it('maps top-level dataset fields and derives startTime', () => {
+      // Given
+      const data = makeData(singleEncode(V2_INNER_QUERY));
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.uuid).toBe('dataset-uuid');
+      expect(dataset.user).toBe('test-user');
+      expect(dataset.name).toBe('Test Dataset');
+      expect(dataset.queryId).toBe('query-uuid');
+      expect(dataset.rawStartTime).toBe(1690000000000);
+      expect(dataset.status).toBe('COMPLETE');
+    });
+
+    it('defaults status to UNDEFINED when missing', () => {
+      // Given
+      const data = makeData(singleEncode(V2_INNER_QUERY));
+      data.query.status = '';
+
+      // When
+      const dataset = mapDataset(data);
+
+      // Then
+      expect(dataset.status).toBe('UNDEFINED');
+    });
+  });
+});

--- a/tests/unit/QueryConverters.test.ts
+++ b/tests/unit/QueryConverters.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { QueryV2, QueryV3 } from '$lib/models/query/Query';
 import { QueryVersion } from '$lib/models/Dataset';
@@ -9,6 +9,7 @@ import type {
   GenomicFilterInterface,
 } from '$lib/models/Filter.svelte';
 import { getConceptDetails, getConceptTree } from '$lib/stores/Dictionary';
+import { features } from '$lib/configuration';
 
 import {
   queryV2ToV3,
@@ -34,6 +35,10 @@ vi.mock('$lib/stores/Filter', () => ({
     operator,
     parent: undefined,
   }),
+}));
+
+vi.mock('$lib/configuration', () => ({
+  features: { explorer: { exportSystemFields: [] as string[] } },
 }));
 
 const mockGetConceptDetails = vi.mocked(getConceptDetails);
@@ -978,5 +983,91 @@ describe('loadQuerySummaryData', () => {
     // Then — filter still created (degraded), path recorded in errors
     expect(data.errors).toEqual([failingPath]);
     expect(data.filterTree.leafNodes).toHaveLength(1);
+  });
+
+  describe('exportSystemFields filtering', () => {
+    afterEach(() => {
+      features.explorer.exportSystemFields = [];
+    });
+
+    it('does not filter select when exportSystemFields is empty', async () => {
+      // Given
+      const query = makeV3Query({
+        select: ['\\\\dataset\\\\age\\\\', '\\\\_consents\\\\'],
+      });
+
+      // When
+      const data = await allLoadQuerySummaryData(query, QueryVersion.V3);
+      const exports = data.exports.map(({ conceptPath }) => conceptPath);
+
+      // Then
+      expect(exports).toEqual(['\\\\dataset\\\\age\\\\', '\\\\_consents\\\\']);
+    });
+
+    it('filters configured system fields out of V3 select/exports', async () => {
+      // Given
+      features.explorer.exportSystemFields = ['\\\\_consents\\\\'];
+      const query = makeV3Query({
+        select: ['\\\\dataset\\\\age\\\\', '\\\\_consents\\\\'],
+      });
+
+      // When
+      const data = await allLoadQuerySummaryData(query, QueryVersion.V3);
+      const exports = data.exports.map(({ conceptPath }) => conceptPath);
+
+      // Then
+      expect(exports).toEqual(['\\\\dataset\\\\age\\\\']);
+    });
+
+    it('filters multiple configured system fields, leaving non-matching fields intact', async () => {
+      // Given
+      features.explorer.exportSystemFields = ['\\\\_consents\\\\', '\\\\_topmed_study\\\\'];
+      const query = makeV3Query({
+        select: [
+          '\\\\dataset\\\\age\\\\',
+          '\\\\_consents\\\\',
+          '\\\\_topmed_study\\\\',
+          '\\\\dataset\\\\sex\\\\',
+        ],
+      });
+
+      // When
+      const data = await allLoadQuerySummaryData(query, QueryVersion.V3);
+      const exports = data.exports.map(({ conceptPath }) => conceptPath);
+
+      // Then
+      expect(exports).toEqual(['\\\\dataset\\\\age\\\\', '\\\\dataset\\\\sex\\\\']);
+    });
+
+    it('filters configured system fields out of V2 queries after conversion to V3', async () => {
+      // Given
+      features.explorer.exportSystemFields = ['\\\\_consents\\\\'];
+      const query = makeV2Query({
+        fields: ['\\\\dataset\\\\age\\\\'],
+        crossCountFields: ['\\\\_consents\\\\'],
+      });
+
+      // When
+      const data = await allLoadQuerySummaryData(query, QueryVersion.V2);
+      const exports = data.exports.map(({ conceptPath }) => conceptPath);
+
+      // Then
+      expect(exports).toEqual(['\\\\dataset\\\\age\\\\']);
+    });
+
+    it('leaves select unchanged when none of the selected fields match exportSystemFields', async () => {
+      // Given
+      features.explorer.exportSystemFields = ['\\\\_consents\\\\'];
+      const query = makeV3Query({
+        select: ['\\\\dataset\\\\age\\\\', '\\\\dataset\\\\sex\\\\'],
+      });
+
+      // When
+      const data = await allLoadQuerySummaryData(query, QueryVersion.V3);
+      const exports = data.exports.map(({ conceptPath }) => conceptPath);
+
+      // Then
+      expect(exports).toEqual(['\\\\dataset\\\\age\\\\', '\\\\dataset\\\\sex\\\\']);
+    });
   });
 });

--- a/tests/unit/QueryConverters.test.ts
+++ b/tests/unit/QueryConverters.test.ts
@@ -180,6 +180,32 @@ describe('queryV2ToV3', () => {
       });
     });
 
+    it('strips categoryFilters entries matching exportSystemFields', () => {
+      // Given
+      features.explorer.exportSystemFields = ['\\\\_consents\\\\'];
+      const query = makeV2Query({
+        categoryFilters: {
+          '\\\\dataset\\\\sex\\\\': ['Male', 'Female'],
+          '\\\\_consents\\\\': ['phs000001.c1'],
+        },
+      });
+
+      try {
+        // When
+        const { phenotypicClause } = queryV2ToV3(query);
+
+        // Then
+        expect(phenotypicClause).toMatchObject({
+          type: 'PhenotypicFilter',
+          phenotypicFilterType: 'FILTER',
+          conceptPath: '\\\\dataset\\\\sex\\\\',
+          values: ['Male', 'Female'],
+        });
+      } finally {
+        features.explorer.exportSystemFields = [];
+      }
+    });
+
     it('maps numericFilters entries to FILTER PhenotypicFilters with numeric min/max', () => {
       // Given
       const query = makeV2Query({


### PR DESCRIPTION
- Add double escaping fixes
- Strip system export fields from query select
- Strip system export fields from V2 category filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query handling for datasets that contain nested serialized query data, so queries now load correctly in more cases.
  * Exported query results now automatically exclude configured system fields, preventing them from appearing in filtered output.
  
* **Tests**
  * Added coverage for query parsing, dataset mapping, and export filtering to verify behavior across single- and double-encoded query data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->