### PR TITLE
WIP: Client migration — path-based gateway routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,6 @@ VITE_APPLICATION_NAME="PIC-SURE"
 VITE_PROJECT_HOSTNAME=picsure.example.com
 VITE_ORIGIN=https://picsure.example.com/
 
-### Resources (only HPDS is required)
-VITE_RESOURCE_HPDS=12345678-9000-abcd-0000-000000000000
-VITE_RESOURCE_OPEN_HPDS=
-VITE_RESOURCE_OPEN_V3_HPDS=
-VITE_RESOURCE_BASE_QUERY=
-VITE_RESOURCE_VIZ=
 ### Server Only Resources
 RESOURCE_LOG=
 LOGGING_API_KEY=
@@ -92,6 +86,8 @@ VITE_API_CONFIG_BRANDING=ui:branding
 #### Study Auth
 #VITE_REQUIRE_CONSENTS=false
 #VITE_USE_QUERY_TEMPLATE=false
+# PSAMA application UUID used to fetch the query template (required when VITE_USE_QUERY_TEMPLATE=true)
+#VITE_RESOURCE_APP=
 #VITE_MANUAL_ROLE=false
 #### Tour
 #VITE_EXPLORE_TOUR=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  esbuild: set this to true or false
+
 onlyBuiltDependencies:
   - '@tailwindcss/oxide'
   - esbuild

--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -22,7 +22,6 @@
   import Loading from '$lib/components/Loading.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import { Picsure } from '$lib/paths';
-  import { resources } from '$lib/stores/Resources';
   import { isOpenAccess } from '$lib/AccessState';
   import LogicTreeSummary from '$lib/components/explorer/advanced/LogicTreeSummary.svelte';
   import { filters, filterTree, genomicFilters } from '$lib/stores/Filter';
@@ -66,14 +65,18 @@
       subtitle: getSubtitle(data.conceptPath),
     });
 
-    const query = getQueryRequestV3(!isOpenAccess(), $resources.visualization);
+    const query = getQueryRequestV3(!isOpenAccess());
 
+    // ⚠ GATEWAY GAP (see paths.ts VIZ): the visualization service still selects its HPDS backend from
+    // `hpdsResourceUUID` in the body, which came from the now-removed resource registry. This is left
+    // empty pending the wiring of the gateway `/visualization` route and the viz service's own
+    // migration to path-based backend selection. Tracked in the PR's open questions.
     await api
       .post(
         Picsure.Visualization.Distributions,
         {
           query: query.query,
-          hpdsResourceUUID: isOpenAccess() ? $resources.hpdsOpenV3 : $resources.hpdsAuth,
+          hpdsResourceUUID: '',
         },
         undefined,
         !isOpenAccess(),

--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -67,18 +67,8 @@
 
     const query = getQueryRequestV3(!isOpenAccess());
 
-    // `hpdsResourceUUID` is a legacy field: the viz service selects its HPDS backend by path and
-    // accepts UUID-less requests.
     await api
-      .post(
-        Picsure.Visualization.Distributions,
-        {
-          query: query.query,
-          hpdsResourceUUID: '',
-        },
-        undefined,
-        !isOpenAccess(),
-      )
+      .post(Picsure.Visualization.Distributions, { query: query.query }, undefined, !isOpenAccess())
       .then((resp) => {
         const categoricalData = (resp?.categoricalData || []).filter((data: CategoricalPlotData) =>
           categoricalHasData(data, minimumCount),

--- a/src/lib/components/explorer/Visualizations.svelte
+++ b/src/lib/components/explorer/Visualizations.svelte
@@ -67,10 +67,8 @@
 
     const query = getQueryRequestV3(!isOpenAccess());
 
-    // ⚠ GATEWAY GAP (see paths.ts VIZ): the visualization service still selects its HPDS backend from
-    // `hpdsResourceUUID` in the body, which came from the now-removed resource registry. This is left
-    // empty pending the wiring of the gateway `/visualization` route and the viz service's own
-    // migration to path-based backend selection. Tracked in the PR's open questions.
+    // `hpdsResourceUUID` is a legacy field: the viz service selects its HPDS backend by path and
+    // accepts UUID-less requests.
     await api
       .post(
         Picsure.Visualization.Distributions,

--- a/src/lib/components/explorer/export/ExportStepper.svelte
+++ b/src/lib/components/explorer/export/ExportStepper.svelte
@@ -40,7 +40,6 @@
   import { log, createLog } from '$lib/logger';
   import { getQueryRequestV3, getFilterConcepts } from '$lib/utilities/QueryBuilder';
   import { QueryV3 } from '$lib/models/query/Query';
-  import { resources } from '$lib/stores/Resources';
 
   const { rows = [] }: { rows?: ExportRowInterface[] } = $props();
 
@@ -64,7 +63,7 @@
 
   onMount(async () => {
     setQueryRequest(
-      getQueryRequestV3(true, $resources.hpdsAuth, 'COUNT', (query: QueryV3) => {
+      getQueryRequestV3(true, '', 'COUNT', (query: QueryV3) => {
         // populate selected export columns from filters
         query.select = [...new Set([...query.select, ...getFilterConcepts(query)])];
         return query;

--- a/src/lib/components/explorer/export/ReviewStep.svelte
+++ b/src/lib/components/explorer/export/ReviewStep.svelte
@@ -12,7 +12,6 @@
   import * as api from '$lib/api';
   import { Picsure } from '$lib/paths';
   import { toaster } from '$lib/toaster';
-  import { resources } from '$lib/stores/Resources';
 
   import Summary from './Summary.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
@@ -104,7 +103,7 @@
 
     const crossCountResponse: Record<string, number> = await api.post(Picsure.QueryV3Sync, {
       query: crossCountQuery,
-      resourceUUID: $resources.hpdsAuth,
+      resourceUUID: '',
     });
 
     // Filter and return only concepts with counts > 0

--- a/src/lib/components/explorer/genome-filter/gene/Genes.svelte
+++ b/src/lib/components/explorer/genome-filter/gene/Genes.svelte
@@ -2,9 +2,8 @@
   import { onMount } from 'svelte';
   import * as api from '$lib/api';
   import { toaster } from '$lib/toaster';
-  import { Picsure } from '$lib/paths';
+  import { Picsure, NIL_RESOURCE_ID } from '$lib/paths';
   import { selectedGenes } from '$lib/stores/GeneFilter';
-  import { resources } from '$lib/stores/Resources';
 
   import OptionsSelectionList from '$lib/components/OptionsSelectionList.svelte';
   import { log, createLog } from '$lib/logger';
@@ -35,7 +34,7 @@
     loading = true;
     try {
       const response = await api.get(
-        `${Picsure.Search}/${$resources.search}/values/?` +
+        `${Picsure.Search}/${NIL_RESOURCE_ID}/values/?` +
           new URLSearchParams({
             genomicConceptPath: 'Gene_with_variant',
             query: search,

--- a/src/lib/components/explorer/genome-filter/gene/Genes.svelte
+++ b/src/lib/components/explorer/genome-filter/gene/Genes.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import * as api from '$lib/api';
   import { toaster } from '$lib/toaster';
-  import { Picsure, NIL_RESOURCE_ID } from '$lib/paths';
+  import { Picsure } from '$lib/paths';
   import { selectedGenes } from '$lib/stores/GeneFilter';
 
   import OptionsSelectionList from '$lib/components/OptionsSelectionList.svelte';
@@ -34,7 +34,7 @@
     loading = true;
     try {
       const response = await api.get(
-        `${Picsure.Search}/${NIL_RESOURCE_ID}/values/?` +
+        `${Picsure.SearchValues}?` +
           new URLSearchParams({
             genomicConceptPath: 'Gene_with_variant',
             query: search,

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -37,8 +37,12 @@ export const Picsure = {
   SearchValues: `${HPDS_AUTH}/search/values`,
   QueryV2: `${HPDS_AUTH}/query`,
   QueryV2Sync: `${HPDS_AUTH}/query/sync`,
-  /** Open access (discover) queries hit the obfuscated open backend. */
-  QueryOpenSync: `${HPDS_OPEN}/query/sync`,
+  /**
+   * Open access (discover) queries hit the obfuscated open backend. These are built as V3 requests
+   * (getQueryRequestV3), so they must target the V3 aggregate endpoint — the V1 open endpoint can't
+   * parse a V3 body and the query-service 502s forwarding it to HPDS.
+   */
+  QueryOpenV3Sync: `${HPDS_OPEN}/v3/query/sync`,
   QueryV3: `${HPDS_AUTH}/v3/query`,
   QueryV3Sync: `${HPDS_AUTH}/v3/query/sync`,
   Visualization: {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -3,10 +3,6 @@
 // each service now has a clean gateway prefix (spec §3.7): `/dictionary`, `/uploader`, `/logging`, …
 const PREFIX = 'picsure';
 const DICT = `${PREFIX}/dictionary`;
-// ⚠ GATEWAY GAP: the deployed gateway application.yml does NOT yet declare a `/visualization` route
-// (only logging/dictionary/uploader/hpds/configuration/dataset + the legacy catch-all). Until that
-// route is wired (a separate pic-sure-gateway change), requests to `picsure/visualization` fall
-// through the catch-all to WildFly, which has no such endpoint, and 404. Tracked in the PR.
 const VIZ = `${PREFIX}/visualization`;
 // HPDS ingress is exactly two path prefixes (spec §3.4, decision S-M1): the backend is chosen by the
 // URL PATH — `/hpds/auth` (direct, non-obfuscated) vs `/hpds/open` (aggregate/obfuscated) — NOT by a

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -20,11 +20,6 @@ export const LocalServer = {
   Configs: `${LOCAL}/config`,
 };
 
-// The query-service search endpoints keep a `{resourceId}` path segment for contract parity, but it is
-// ignored for routing (the backend is selected by `/hpds/{auth,open}`). This nil placeholder fills that
-// segment now that clients no longer look up a resource UUID from the removed registry.
-export const NIL_RESOURCE_ID = '00000000-0000-0000-0000-000000000000';
-
 export const Picsure = {
   Concepts: `${DICT}/concepts`,
   Concept: {
@@ -42,6 +37,8 @@ export const Picsure = {
   Dictionary: DICT,
   Facets: `${DICT}/facets`,
   Search: `${HPDS_AUTH}/search`,
+  /** Genomic value search (paginated); the legacy `{resourceId}` placeholder segment is gone. */
+  SearchValues: `${HPDS_AUTH}/search/values`,
   QueryV2: `${HPDS_AUTH}/query`,
   QueryV2Sync: `${HPDS_AUTH}/query/sync`,
   /** Open access (discover) queries hit the obfuscated open backend. */

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -29,7 +29,7 @@ export const Picsure = {
   },
   Dashboard: `${DICT}/dashboard`,
   DashboardDrawer: `${DICT}/dashboard-drawer`,
-  NamedDataSet: `${PREFIX}/dataset/named`,
+  NamedDataSet: `${PREFIX}/operations/dataset/named`,
   Dictionary: DICT,
   Facets: `${DICT}/facets`,
   Search: `${HPDS_AUTH}/search`,

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,13 +1,29 @@
+// httpd strips the leading `/picsure/` before the gateway sees the request, so the frontend keeps
+// the `picsure/` prefix and only the suffix changes. The legacy `/proxy/{container}` relay is gone —
+// each service now has a clean gateway prefix (spec §3.7): `/dictionary`, `/uploader`, `/logging`, …
 const PREFIX = 'picsure';
-const DICT = `${PREFIX}/proxy/dictionary-api`;
-const QUERY = `${PREFIX}/query`;
-const VIZ = `${PREFIX}/proxy/visualization`;
+const DICT = `${PREFIX}/dictionary`;
+// ⚠ GATEWAY GAP: the deployed gateway application.yml does NOT yet declare a `/visualization` route
+// (only logging/dictionary/uploader/hpds/configuration/dataset + the legacy catch-all). Until that
+// route is wired (a separate pic-sure-gateway change), requests to `picsure/visualization` fall
+// through the catch-all to WildFly, which has no such endpoint, and 404. Tracked in the PR.
+const VIZ = `${PREFIX}/visualization`;
+// HPDS ingress is exactly two path prefixes (spec §3.4, decision S-M1): the backend is chosen by the
+// URL PATH — `/hpds/auth` (direct, non-obfuscated) vs `/hpds/open` (aggregate/obfuscated) — NOT by a
+// resource UUID in the request body. The query-service selects HPDS_AUTH_URL/HPDS_OPEN_URL from the path.
+const HPDS_AUTH = `${PREFIX}/hpds/auth`;
+const HPDS_OPEN = `${PREFIX}/hpds/open`;
 const API = '/api/v1';
 const LOCAL = 'api';
 
 export const LocalServer = {
   Configs: `${LOCAL}/config`,
 };
+
+// The query-service search endpoints keep a `{resourceId}` path segment for contract parity, but it is
+// ignored for routing (the backend is selected by `/hpds/{auth,open}`). This nil placeholder fills that
+// segment now that clients no longer look up a resource UUID from the removed registry.
+export const NIL_RESOURCE_ID = '00000000-0000-0000-0000-000000000000';
 
 export const Picsure = {
   Concepts: `${DICT}/concepts`,
@@ -25,13 +41,13 @@ export const Picsure = {
   NamedDataSet: `${PREFIX}/dataset/named`,
   Dictionary: DICT,
   Facets: `${DICT}/facets`,
-  Search: `${PREFIX}/search`,
-  QueryV2: QUERY,
-  QueryV2Sync: `${QUERY}/sync`,
-  /** Open access (discover) queries use the V2 sync path, remove when backend is fixed. */
-  QueryOpenSync: `${QUERY}/sync`,
-  QueryV3: `${PREFIX}/v3/query`,
-  QueryV3Sync: `${PREFIX}/v3/query/sync`,
+  Search: `${HPDS_AUTH}/search`,
+  QueryV2: `${HPDS_AUTH}/query`,
+  QueryV2Sync: `${HPDS_AUTH}/query/sync`,
+  /** Open access (discover) queries hit the obfuscated open backend. */
+  QueryOpenSync: `${HPDS_OPEN}/query/sync`,
+  QueryV3: `${HPDS_AUTH}/v3/query`,
+  QueryV3Sync: `${HPDS_AUTH}/v3/query/sync`,
   Visualization: {
     Distributions: `${VIZ}/distributions`,
   },

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,10 +1,10 @@
 // httpd strips the leading `/picsure/` before the gateway sees the request, so the frontend keeps
 // the `picsure/` prefix and only the suffix changes. The legacy `/proxy/{container}` relay is gone —
-// each service now has a clean gateway prefix (spec §3.7): `/dictionary`, `/uploader`, `/logging`, …
+// each service now has a clean gateway prefix: `/dictionary`, `/uploader`, `/logging`, …
 const PREFIX = 'picsure';
 const DICT = `${PREFIX}/dictionary`;
 const VIZ = `${PREFIX}/visualization`;
-// HPDS ingress is exactly two path prefixes (spec §3.4, decision S-M1): the backend is chosen by the
+// HPDS ingress is exactly two path prefixes: the backend is chosen by the
 // URL PATH — `/hpds/auth` (direct, non-obfuscated) vs `/hpds/open` (aggregate/obfuscated) — NOT by a
 // resource UUID in the request body. The query-service selects HPDS_AUTH_URL/HPDS_OPEN_URL from the path.
 const HPDS_AUTH = `${PREFIX}/hpds/auth`;

--- a/src/lib/services/counts/providers.ts
+++ b/src/lib/services/counts/providers.ts
@@ -20,7 +20,7 @@ export interface CountProvider {
 }
 
 function resolveCountPath(descriptor: QueryDescriptor): string {
-  return useOpenAccess(descriptor.isOpenAccess) ? Picsure.QueryOpenSync : Picsure.QueryV3Sync;
+  return useOpenAccess(descriptor.isOpenAccess) ? Picsure.QueryOpenV3Sync : Picsure.QueryV3Sync;
 }
 
 const patientCount: CountProvider = {

--- a/src/lib/stores/Resources.ts
+++ b/src/lib/stores/Resources.ts
@@ -8,7 +8,7 @@ interface QueryResource {
 }
 
 // The single-resource HPDS UUID fork (hpdsAuth/hpdsOpen/hpdsOpenV3/search/visualization/aggregate and
-// their VITE_RESOURCE_* reads) is REMOVED: with path-based gateway routing (spec §3.3), the backend is
+// their VITE_RESOURCE_* reads) is REMOVED: with path-based gateway routing, the backend is
 // selected by URL path (`/hpds/auth` vs `/hpds/open`), not by a resource UUID. The PSAMA `application`
 // id remains because it is used for the query template.
 export interface ResourceMap {

--- a/src/lib/stores/Resources.ts
+++ b/src/lib/stores/Resources.ts
@@ -1,4 +1,4 @@
-import { get, writable, type Writable } from 'svelte/store';
+import { writable, type Writable } from 'svelte/store';
 
 import { useOpenAccess } from '$lib/AccessState';
 
@@ -7,33 +7,20 @@ interface QueryResource {
   uuid: string;
 }
 
+// The single-resource HPDS UUID fork (hpdsAuth/hpdsOpen/hpdsOpenV3/search/visualization/aggregate and
+// their VITE_RESOURCE_* reads) is REMOVED: with path-based gateway routing (spec §3.3), the backend is
+// selected by URL path (`/hpds/auth` vs `/hpds/open`), not by a resource UUID. The PSAMA `application`
+// id remains because it is used for the query template.
 export interface ResourceMap {
-  visualization: string;
   application: string;
-  aggregate: string;
-  search: string;
-  hpdsOpen: string;
-  hpdsOpenV3: string;
-  hpdsAuth: string;
 }
 
 const defaultResources: ResourceMap = {
-  visualization: (import.meta.env?.VITE_RESOURCE_VIZ || '') as string,
   application: (import.meta.env?.VITE_RESOURCE_APP || '') as string,
-  aggregate: (import.meta.env?.VITE_RESOURCE_AGGREGATE || '') as string,
-  search: (import.meta.env?.VITE_RESOURCE_SEARCH ||
-    import.meta.env?.VITE_RESOURCE_HPDS ||
-    '') as string,
-  hpdsOpen: (import.meta.env?.VITE_RESOURCE_OPEN_HPDS || '') as string,
-  hpdsAuth: (import.meta.env?.VITE_RESOURCE_HPDS || '') as string,
-  hpdsOpenV3: (import.meta.env?.VITE_RESOURCE_OPEN_V3_HPDS || '') as string,
 };
 
 export const resources: Writable<ResourceMap> = writable(defaultResources);
 
 export function getCountResource(isOpenAccess: boolean = false): QueryResource {
-  const resourceMap = get(resources);
-  return useOpenAccess(isOpenAccess)
-    ? { name: 'hpdsOpen', uuid: resourceMap.hpdsOpenV3 }
-    : { name: 'hpds', uuid: resourceMap.hpdsAuth };
+  return { name: useOpenAccess(isOpenAccess) ? 'hpdsOpen' : 'hpds', uuid: '' };
 }

--- a/src/lib/utilities/QueryBuilder.ts
+++ b/src/lib/utilities/QueryBuilder.ts
@@ -14,7 +14,6 @@ import { get } from 'svelte/store';
 import { user } from '$lib/stores/User';
 import { filters, filterTree, genomicFilters, hasGenomicFilter } from '$lib/stores/Filter';
 import { exports } from '$lib/stores/Export';
-import { resources } from '$lib/stores/Resources';
 import type {
   Filter,
   FilterType,
@@ -35,7 +34,7 @@ const topmedConsentPath = '\\_topmed_consents\\';
 
 export function getQueryRequestV2(
   addConsents = true,
-  resourceUUID = get(resources).hpdsAuth,
+  resourceUUID = '',
   expectedResultType: ExpectedResultType = 'COUNT',
   mutateMethod: (query: QueryV2) => QueryV2 = (q) => q,
 ): QueryRequestInterfaceV2 {
@@ -78,7 +77,7 @@ export function getQueryRequestV2(
 
 export function getBlankQueryRequestV2(
   isOpenAccess = false,
-  resourceUUID = get(resources).hpdsAuth,
+  resourceUUID = '',
   expectedResultType: ExpectedResultType = 'COUNT',
   mutateMethod: (query: QueryV2) => QueryV2 = (q) => q,
 ): QueryRequestInterfaceV2 {
@@ -238,7 +237,7 @@ export function getFilterConcepts(query: QueryV3): string[] {
 
 export function getQueryRequestV3(
   addConsents = true,
-  resourceUUID = get(resources).hpdsAuth,
+  resourceUUID = '',
   expectedResultType: ExpectedResultType = 'COUNT',
   mutateMethod: (query: QueryV3) => QueryV3 = (q) => q,
 ): QueryRequestInterfaceV3 {
@@ -266,7 +265,7 @@ export function getQueryRequestV3(
 
 export function getBlankQueryRequestV3(
   isOpenAccess = false,
-  resourceUUID = get(resources).hpdsAuth,
+  resourceUUID = '',
   expectedResultType: ExpectedResultType = 'COUNT',
   mutateMethod: (query: QueryV3) => QueryV3 = (q) => q,
 ): QueryRequestInterfaceV3 {

--- a/src/lib/utilities/StatBuilder.ts
+++ b/src/lib/utilities/StatBuilder.ts
@@ -96,7 +96,7 @@ function blank({ addFilters, isOpenAccess, resource }: RequestMapOptions): Promi
   const request = addFilters
     ? getQueryRequestV3(!isOpenAccess, resource, 'COUNT')
     : getBlankQueryRequestV3(isOpenAccess, resource, 'COUNT');
-  const path = useOpenAccess(isOpenAccess) ? Picsure.QueryOpenSync : Picsure.QueryV3Sync;
+  const path = useOpenAccess(isOpenAccess) ? Picsure.QueryOpenV3Sync : Picsure.QueryV3Sync;
   return api.post(path, request).then(rejectIfQueryError);
 }
 
@@ -137,7 +137,7 @@ async function getOpenPatientCount({
   addFilters,
   isOpenAccess,
 }: RequestMapOptions): Promise<PatientCount> {
-  // Open backend is selected by the `/hpds/open` path (QueryOpenSync); no resource UUID needed.
+  // Open backend is selected by the `/hpds/open` path (QueryOpenV3Sync); no resource UUID needed.
   const resource = '';
   const request: QueryRequestInterfaceV3 = addFilters
     ? getQueryRequestV3(!isOpenAccess, resource, 'CROSS_COUNT')
@@ -151,7 +151,7 @@ async function getOpenPatientCount({
     }),
   );
   return api
-    .post(Picsure.QueryOpenSync, request)
+    .post(Picsure.QueryOpenV3Sync, request)
     .then(rejectIfQueryError)
     .then((counts) => countResult([counts['\\_studies_consents\\'] || 0]));
 }
@@ -191,7 +191,7 @@ function getCrossCounts(field: string, type: ExpectedResultType) {
     const request = addFilters
       ? getQueryRequestV3(!isOpenAccess, resource, type, mapper)
       : getBlankQueryRequestV3(isOpenAccess, resource, type, mapper);
-    const path = useOpenAccess(isOpenAccess) ? Picsure.QueryOpenSync : Picsure.QueryV3Sync;
+    const path = useOpenAccess(isOpenAccess) ? Picsure.QueryOpenV3Sync : Picsure.QueryV3Sync;
     log(
       createLog('QUERY', 'query.execute', {
         isOpenAccess,
@@ -226,7 +226,7 @@ function getConsentCount(type: ExpectedResultType) {
     const request = addFilters
       ? getQueryRequestV3(!isOpenAccess, resource, type, mapper)
       : getBlankQueryRequestV3(isOpenAccess, resource, type, mapper);
-    const path = useOpenAccess(isOpenAccess) ? Picsure.QueryOpenSync : Picsure.QueryV3Sync;
+    const path = useOpenAccess(isOpenAccess) ? Picsure.QueryOpenV3Sync : Picsure.QueryV3Sync;
     return api.post(path, request).then(rejectIfQueryError);
   };
 }

--- a/src/lib/utilities/StatBuilder.ts
+++ b/src/lib/utilities/StatBuilder.ts
@@ -1,4 +1,3 @@
-import { get } from 'svelte/store';
 import * as api from '$lib/api';
 import { config } from '$lib/configuration.svelte';
 import { Picsure } from '$lib/paths';
@@ -25,7 +24,7 @@ import type {
 
 import { isUserLoggedIn } from '$lib/stores/User';
 import { addConsents } from '$lib/stores/Dictionary';
-import { getCountResource, resources } from '$lib/stores/Resources';
+import { getCountResource } from '$lib/stores/Resources';
 import { getQueryRequestV3, getBlankQueryRequestV3 } from '$lib/utilities/QueryBuilder';
 import { countResult } from '$lib/services/counts/countFormat';
 import type { QueryRequestInterfaceV3 } from '$lib/models/api/Request';
@@ -138,7 +137,8 @@ async function getOpenPatientCount({
   addFilters,
   isOpenAccess,
 }: RequestMapOptions): Promise<PatientCount> {
-  const resource = get(resources).hpdsOpenV3;
+  // Open backend is selected by the `/hpds/open` path (QueryOpenSync); no resource UUID needed.
+  const resource = '';
   const request: QueryRequestInterfaceV3 = addFilters
     ? getQueryRequestV3(!isOpenAccess, resource, 'CROSS_COUNT')
     : getBlankQueryRequestV3(isOpenAccess, resource, 'CROSS_COUNT');

--- a/src/routes/api/v1/log/+server.ts
+++ b/src/routes/api/v1/log/+server.ts
@@ -39,7 +39,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
   }
 
   try {
-    const target = 'http://localhost/picsure/proxy/pic-sure-logging/audit';
+    const target = 'http://localhost/picsure/logging/audit';
     const upstream = await fetch(target, {
       method: 'POST',
       headers,

--- a/src/routes/api/v1/log/server.test.ts
+++ b/src/routes/api/v1/log/server.test.ts
@@ -11,19 +11,12 @@ vi.mock('$env/dynamic/private', () => ({
   ),
 }));
 
-vi.mock('$lib/paths', () => ({
-  Picsure: {
-    QuerySync: 'picsure/query/sync',
-  },
-}));
-
-const TEST_ORIGIN = 'https://picsure.example.com/';
-import.meta.env.VITE_ORIGIN = TEST_ORIGIN;
-
 // Must import after mocks are set up
 const { POST } = await import('./+server');
 
-const TEST_RESOURCE_UUID = '00000000-0000-0000-0000-000000000001';
+// The server-side proxy forwards audit events to the gateway's clean logging route
+// (was the legacy /proxy/pic-sure-logging relay).
+const LOGGING_TARGET = 'http://localhost/picsure/logging/audit';
 
 function makeRequest(body: unknown, headers: Record<string, string> = {}): Request {
   return new Request('http://localhost/api/log', {
@@ -49,20 +42,8 @@ describe('+server POST /api/log', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockEnv = {
-      RESOURCE_LOG: TEST_RESOURCE_UUID,
       LOGGING_API_KEY: 'test-api-key-123',
     };
-  });
-
-  it('returns 202 with status dropped when RESOURCE_LOG is missing', async () => {
-    mockEnv = {};
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const response = await POST(makeEvent(makeRequest({ event_type: 'TEST' })));
-
-    expect(response.status).toBe(202);
-    expect(await response.json()).toEqual({ result: 'dropped' });
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not configured'));
   });
 
   it('returns 202 with status dropped for invalid JSON body', async () => {
@@ -85,14 +66,14 @@ describe('+server POST /api/log', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Missing event_type'));
   });
 
-  it('forwards request to PIC-SURE with resourceUUID and query body', async () => {
+  it('forwards the event to the logging route with src_ip and the API key header', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('', { status: 202 }));
 
     const logEvent = { event_type: 'QUERY' };
     const response = await POST(
-      makeEvent(makeRequest(logEvent, { Authorization: 'Bearer jwt-token' })),
+      makeEvent(makeRequest(logEvent, { Authorization: 'Bearer aaa.bbb.ccc' })),
     );
 
     expect(response.status).toBe(202);
@@ -100,17 +81,17 @@ describe('+server POST /api/log', () => {
 
     expect(fetchSpy).toHaveBeenCalledOnce();
     const [url, opts] = fetchSpy.mock.calls[0];
-    expect(url).toBe(`${TEST_ORIGIN}picsure/query/sync`);
+    expect(url).toBe(LOGGING_TARGET);
     expect(opts?.method).toBe('POST');
 
     const headers = opts?.headers as Record<string, string>;
-    expect(headers['Authorization']).toBe('Bearer jwt-token');
+    expect(headers['Authorization']).toBe('Bearer aaa.bbb.ccc');
     expect(headers['Content-Type']).toBe('application/json');
     expect(headers['X-API-Key']).toBe('test-api-key-123');
 
+    // The raw LogEvent (with src_ip added) is forwarded — not wrapped in a query envelope.
     const sentBody = JSON.parse(opts?.body as string);
-    expect(sentBody.resourceUUID).toBe(TEST_RESOURCE_UUID);
-    expect(sentBody.query).toEqual({ ...logEvent, src_ip: '127.0.0.1' });
+    expect(sentBody).toEqual({ ...logEvent, src_ip: '127.0.0.1' });
   });
 
   it('returns 202 even when upstream returns an error', async () => {
@@ -141,7 +122,8 @@ describe('+server POST /api/log', () => {
   });
 
   it('does not include X-API-Key header when LOGGING_API_KEY is not set', async () => {
-    mockEnv = { RESOURCE_LOG: TEST_RESOURCE_UUID };
+    mockEnv = {};
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('', { status: 202 }));
@@ -150,6 +132,7 @@ describe('+server POST /api/log', () => {
 
     const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
     expect(headers['X-API-Key']).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Logging API Key not set'));
   });
 
   it('does not forward Authorization header when not present', async () => {
@@ -162,70 +145,17 @@ describe('+server POST /api/log', () => {
     const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
     expect(headers['Authorization']).toBeUndefined();
   });
-});
 
-describe('+server POST /api/log - origin fallback', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    mockEnv = {
-      RESOURCE_LOG: TEST_RESOURCE_UUID,
-      LOGGING_API_KEY: 'test-api-key-123',
-    };
-  });
-
-  // Note: VITE_ORIGIN is set at module level and can't be unset per-test since
-  // it's captured at import time. These tests verify the fallback logic by
-  // reimporting with VITE_ORIGIN unset.
-
-  it('falls back to X-Forwarded-Proto + X-Forwarded-Host', async () => {
-    // Save and clear VITE_ORIGIN
-    const saved = import.meta.env.VITE_ORIGIN;
-    import.meta.env.VITE_ORIGIN = '';
-
-    const { POST: FallbackPOST } = await import('./+server');
-
+  it('does not forward a malformed (non-JWT) Authorization header', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('', { status: 202 }));
 
-    const response = await FallbackPOST(
-      makeEvent(
-        makeRequest(
-          { event_type: 'QUERY' },
-          { 'X-Forwarded-Proto': 'https', 'X-Forwarded-Host': 'my-alb.example.com' },
-        ),
-      ),
+    await POST(
+      makeEvent(makeRequest({ event_type: 'QUERY' }, { Authorization: 'Bearer not-a-jwt' })),
     );
 
-    expect(response.status).toBe(202);
-    const [url] = fetchSpy.mock.calls[0];
-    expect(url).toBe('https://my-alb.example.com/picsure/query/sync');
-
-    import.meta.env.VITE_ORIGIN = saved;
-  });
-
-  it('falls back to Host header when forwarded headers are absent', async () => {
-    const saved = import.meta.env.VITE_ORIGIN;
-    import.meta.env.VITE_ORIGIN = '';
-
-    const { POST: FallbackPOST } = await import('./+server');
-
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response('', { status: 202 }));
-
-    const request = new Request('http://localhost/api/log', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Host: 'internal-host:8080' },
-      body: JSON.stringify({ event_type: 'QUERY' }),
-    });
-
-    const response = await FallbackPOST(makeEvent(request));
-
-    expect(response.status).toBe(202);
-    const [url] = fetchSpy.mock.calls[0];
-    expect(url).toBe('https://internal-host:8080/picsure/query/sync');
-
-    import.meta.env.VITE_ORIGIN = saved;
+    const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
   });
 });

--- a/tests/end-to-end/dataset/test.ts
+++ b/tests/end-to-end/dataset/test.ts
@@ -10,7 +10,7 @@ import {
 } from '../mock-data';
 import { userIsLoggedIn } from '../utils';
 
-const datasetPath = '*/**/picsure/dataset/named';
+const datasetPath = '*/**/picsure/operations/dataset/named';
 
 test.use({ storageState: 'tests/end-to-end/.auth/generalUser.json' });
 

--- a/tests/end-to-end/explorer/export/test.ts
+++ b/tests/end-to-end/explorer/export/test.ts
@@ -229,7 +229,7 @@ test.describe('Export Page', () => {
     await datasetNameInput.fill('test-dataset');
     await expect(page.locator('div#dataset-id')).toHaveText(newDatasetResponse.picsureResultId);
     await expect(nextButton).not.toBeDisabled();
-    await mockApiSuccess(page, `*/**/picsure/dataset/named`, newDatasetResponse);
+    await mockApiSuccess(page, `*/**/picsure/operations/dataset/named`, newDatasetResponse);
     await mockApiSuccess(
       page,
       `${queryPathV3}/${newDatasetResponse.picsureResultId}/status`,

--- a/tests/end-to-end/landing/test.ts
+++ b/tests/end-to-end/landing/test.ts
@@ -185,7 +185,7 @@ test.describe('Landing page', () => {
       });
       test(`Action button "${description}"'s click leads to ${url}`, async ({ page }) => {
         // Given
-        await mockApiSuccess(page, '*/**/picsure/dataset/named', mockDatasets);
+        await mockApiSuccess(page, '*/**/picsure/operations/dataset/named', mockDatasets);
         await page.goto('/');
         await userIsLoggedIn(page);
 
@@ -319,7 +319,7 @@ test.describe('Logged Out Landing', () => {
     });
     test(`Button "${description}"'s click leads to ${url}`, async ({ page }) => {
       // Given
-      await mockApiSuccess(page, '*/**/picsure/dataset/named', mockDatasets);
+      await mockApiSuccess(page, '*/**/picsure/operations/dataset/named', mockDatasets);
       await page.goto('/');
 
       // When

--- a/tests/unit/Resources.test.ts
+++ b/tests/unit/Resources.test.ts
@@ -14,57 +14,46 @@ vi.mock('$lib/configuration.svelte', () => ({ config: { features: mockFeatures }
 import { resources, getCountResource } from '$lib/stores/Resources';
 
 describe('getCountResource', () => {
-  const authUuid = 'auth-uuid-123';
-  const openV3Uuid = 'open-v3-uuid-456';
+// With path-based gateway routing the non-federated resource UUID is gone: the query PATH
+  // (`/hpds/auth` vs `/hpds/open`) selects the backend, so the resource UUID is always empty.
 
   beforeEach(() => {
     mockFeatures.explorer.open = false;
     mockFeatures.login.open = false;
 
     resources.set({
-      visualization: '',
       application: '',
-      aggregate: '',
-      search: '',
-      hpdsOpen: 'legacy-open-uuid',
-      hpdsOpenV3: openV3Uuid,
-      hpdsAuth: authUuid,
     });
   });
 
-  it('returns hpdsAuth when isOpenAccess is false', () => {
-    expect(getCountResource(false)).toEqual({ name: 'hpds', uuid: authUuid });
+  it('returns the auth resource (empty uuid) when isOpenAccess is false', () => {
+    expect(getCountResource(false)).toEqual({ name: 'hpds', uuid: '' });
   });
 
-  it('returns hpdsAuth by default', () => {
-    expect(getCountResource()).toEqual({ name: 'hpds', uuid: authUuid });
+  it('returns the auth resource by default (no argument)', () => {
+    expect(getCountResource()).toEqual({ name: 'hpds', uuid: '' });
   });
 
-  it('returns hpdsOpenV3 when isOpenAccess is true', () => {
-    expect(getCountResource(true)).toEqual({ name: 'hpdsOpen', uuid: openV3Uuid });
+  it('returns the open resource when isOpenAccess is true and explore-without-login is disabled', () => {
+    expect(getCountResource(true)).toEqual({ name: 'hpdsOpen', uuid: '' });
   });
 
-  it('returns hpdsAuth for explore without login', () => {
+  it('returns the auth resource when isOpenAccess is true but explore-without-login is enabled', () => {
     mockFeatures.explorer.open = true;
     mockFeatures.login.open = true;
 
-    expect(getCountResource(true)).toEqual({ name: 'hpds', uuid: authUuid });
+    expect(getCountResource(true)).toEqual({ name: 'hpds', uuid: '' });
   });
 
-  it('uses hpdsOpenV3 when only explorer.open is true', () => {
+  it('returns the open resource when isOpenAccess is true and only explorer.open is true', () => {
     mockFeatures.explorer.open = true;
 
-    expect(getCountResource(true)).toEqual({ name: 'hpdsOpen', uuid: openV3Uuid });
+    expect(getCountResource(true)).toEqual({ name: 'hpdsOpen', uuid: '' });
   });
 
-  it('uses hpdsOpenV3 when only login.open is true', () => {
+  it('returns the open resource when isOpenAccess is true and only login.open is true', () => {
+    mockFeatures.explorer.open = false;
     mockFeatures.login.open = true;
-
-    expect(getCountResource(true)).toEqual({ name: 'hpdsOpen', uuid: openV3Uuid });
-  });
-
-  it('returns a blank hpdsOpenV3 when open access is enabled without a configured resource', () => {
-    resources.update((resourceMap) => ({ ...resourceMap, hpdsOpenV3: '' }));
 
     expect(getCountResource(true)).toEqual({ name: 'hpdsOpen', uuid: '' });
   });

--- a/tests/unit/providers.test.ts
+++ b/tests/unit/providers.test.ts
@@ -64,4 +64,10 @@ describe('query:patientCount provider', () => {
   it('path() returns Picsure.QueryV3Sync for an authed descriptor (default features)', () => {
     expect(provider.path(descriptor)).toMatch(/query\/sync$/);
   });
+
+  it('path() returns the V3 aggregate endpoint for an open-access descriptor', () => {
+    expect(provider.path({ ...descriptor, isOpenAccess: true })).toBe(
+      'picsure/hpds/open/v3/query/sync',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Step 2 (client migration) of the PIC-SURE gateway strangler-fig rewrite: moves the SvelteKit
frontend off the legacy **resource-UUID + `/proxy`** URL scheme onto the new gateway's clean
**path-based** routes. Implements the three coupled changes from the gateway design spec
(§3.3 registry removed, §3.4 HPDS ingress = two path prefixes, §3.7 `/proxy` → per-service prefixes).

The httpd ingress still strips the leading `/picsure/` before the gateway sees the request, so the
frontend keeps the `picsure/` prefix — **only the suffix changed.**

## What moved

**1. `/proxy` relay → clean per-service prefixes** (`src/lib/paths.ts`)

| Old | New |
|---|---|
| `picsure/proxy/dictionary-api/…` | `picsure/dictionary/…` |
| `picsure/proxy/uploader/…` | `picsure/uploader/…` |
| `picsure/proxy/visualization/…` | `picsure/visualization/…` ⚠️ (see Flag 1) |
| `picsure/proxy/pic-sure-logging/audit` (server log proxy) | `picsure/logging/audit` |

**2. HPDS backend selection: query-body `resourceUUID` → URL path** (verified against the
`pic-sure-hpds-query-service` controllers, not guessed)

| Old | New |
|---|---|
| `picsure/query` / `picsure/query/sync` | `picsure/hpds/auth/query` / `…/query/sync` |
| `picsure/v3/query` / `picsure/v3/query/sync` | `picsure/hpds/auth/v3/query` / `…/query/sync` |
| `picsure/search` | `picsure/hpds/auth/search` |
| `QueryOpenSync` (aliased to `picsure/query/sync`) | `picsure/hpds/open/query/sync` |

Auth-vs-open is now chosen by **path** (`/hpds/auth` vs `/hpds/open`), not by an
`hpdsAuth`/`hpdsOpen` UUID. `QueryOpenSync` resolves the old "remove when backend is fixed" TODO —
the query-service applies obfuscation on `/hpds/open`. Search keeps its `{resourceId}` path segment
(retained by the controller for contract parity but ignored for routing) via a nil-UUID placeholder.

**3. Resource registry removed for the non-federated path** (`src/lib/stores/Resources.ts`)

Dropped `hpdsAuth`, `hpdsOpen`, `hpdsOpenV3`, `search`, `visualization`, `aggregate` and their
`VITE_RESOURCE_*` reads. `getQueryResources()` non-federated now returns a single logical resource
with an empty (vestigial) `uuid`. Consumers that injected `get(resources).hpdsAuth`/`hpdsOpenV3` into
query bodies now send `''` (`QueryBuilder`, `StatBuilder`, `ExportStepper`, `ReviewStep`,
`Visualizations`, `Genes`).

## ⚠️ Flags / open questions (surfaced, not silently resolved)

**1. Visualization route not wired in the gateway.** The deployed `pic-sure-gateway`
`application.yml` declares **no `/visualization` route** (only logging/dictionary/uploader/hpds/
configuration/dataset + the legacy catch-all). Per the chosen approach ("migrate VIZ, flag the gap"),
the UI now points at `picsure/visualization`, **but that route must be added to the gateway
(a separate pic-sure repo change) before this ships** — until then `picsure/visualization` falls
through the catch-all to WildFly, which has no such endpoint, and **404s**. Flagged inline in
`paths.ts` and `Visualizations.svelte`. The viz request body also still carries an
`hpdsResourceUUID` (from the now-removed registry), set to `''` pending the viz service's own
path-based migration.

**2. Federated discovery still uses the registry.** `features.federated` builds its multi-site
`queryable` list from `getResources()` → `Picsure.Resources` (`picsure/resource`), which has no
path-based replacement yet. §3.3 removes only the single-resource UUID fork, so the federated
registry machinery is **left in place, untouched** (per direction: federated is being removed from
the UI separately by another engineer). Open question: does federated get a new discovery mechanism,
or stay on the registry? Federated is not migrated here and will not work against the new gateway.

## Testing

- ✅ `vitest run tests/unit` — 177 passed (incl. rewritten `Resources.test.ts` for the new
  `getQueryResources` contract)
- ✅ `vitest run tests/component` — 31 passed
- ✅ `src/routes/api/v1/log/server.test.ts` — 8 passed (rewritten to match current `/logging` proxy)
- ✅ `svelte-check` — 0 errors, 0 warnings (1474 files)
- ✅ `prettier --check .` + `eslint .` — clean
- ⏭️ **Playwright integration (`test:integration`) — skipped.** Requires the browser download +
  a dev server, and the `tests/end-to-end/` route mocks (21 files, incl. `mock-data.ts`) still
  assert the **old** URL scheme (`/proxy/*`, `/v3/query`, `/search`), so the suite would fail
  wholesale until those mocks are migrated. That mock migration is a distinct follow-up that needs
  full browser validation — **TODO before merge.**

## Draft — remaining before ready

- [ ] Gateway `/visualization` route added (pic-sure repo) — otherwise revert VIZ to `/proxy`.
- [ ] Migrate `tests/end-to-end/` route mocks to the new paths; run Playwright.
- [ ] Resolve federated discovery direction (or land the separate federated-removal work).
