### PR TITLE
[CHORE] Skip playwright caching by using the officail image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,9 @@ jobs:
   playwright:
     runs-on: ubuntu-22.04
     needs: [lint, typecheck]
+    container:
+      # this version must match the @playwright/test version in package.json
+      image: mcr.microsoft.com/playwright@sha256:9bd26ad900bb5e0f4dee75839e957a89ae89c2b7ab1e76050e559790e946b948 # v1.60.0-noble
     strategy:
       fail-fast: false
       matrix:
@@ -135,15 +138,8 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Cache Playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Sync SvelteKit
         run: pnpm svelte-kit sync
-      - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
         run: pnpm run test:integration --shard=${{ matrix.shard }} --reporter=blob
       - name: Upload blob report


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Playwright test environment to use a pinned container image.
  * Streamlined browser setup by using the browsers included in the test container.
  * Preserved SvelteKit synchronization before running test shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->