### PR TITLE
[ALS-12222] Public access key generation on the API page

### DIFF
--- a/src/lib/assets/configuration.json
+++ b/src/lib/assets/configuration.json
@@ -154,7 +154,8 @@
       { "text": "Retrieve counts for feasibility assessments" },
       { "text": "Filter on genomic variants" },
       { "text": "Retrieve authorized, participant-level data", "requiresLogin": true }
-    ]
+    ],
+    "publicKeyEnabled": true
   },
   "analysisPage": {
     "analysis": {

--- a/src/lib/components/PublicAccessKey.svelte
+++ b/src/lib/components/PublicAccessKey.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import { post } from '$lib/api';
+  import { Psama } from '$lib/paths';
+  import { log, createLog } from '$lib/logger';
+  import CopyButton from '$lib/components/buttons/CopyButton.svelte';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import Loading from '$lib/components/Loading.svelte';
+
+  interface PublicKey {
+    apiKey: string;
+    uuid: string;
+    displayPrefix: string;
+    keyType: string;
+    expiresAt: string;
+  }
+
+  type View = 'idle' | 'form' | 'revealed' | 'error';
+
+  // deployment capability from branding config; the backend independently enforces its own flag
+  let { enabled = false }: { enabled?: boolean } = $props();
+
+  let view: View = $state('idle');
+  let name = $state('');
+  let email = $state('');
+  let submitting = $state(false);
+  let publicKey: PublicKey | undefined = $state();
+  let errorMessage = $state('');
+  let firstField: HTMLInputElement | undefined = $state();
+  let warning: HTMLElement | undefined = $state();
+
+  // moving between states unmounts the focused button; land focus somewhere meaningful,
+  // especially on the see-once warning so screen readers announce it
+  $effect(() => {
+    if (view === 'form') firstField?.focus();
+    else if (view === 'revealed') warning?.focus();
+  });
+
+  let expires = $derived(
+    publicKey
+      ? new Date(publicKey.expiresAt).toLocaleString(undefined, {
+          dateStyle: 'long',
+          timeStyle: 'short',
+        })
+      : '',
+  );
+
+  function extractErrorMessage(err: unknown): string {
+    const fallback = 'Unable to generate a public access key. Please try again later.';
+    const message = (err as { body?: { message?: string } })?.body?.message;
+    if (!message) return fallback;
+    try {
+      const parsed = JSON.parse(message);
+      return typeof parsed === 'string' ? parsed : parsed?.message || fallback;
+    } catch {
+      return message;
+    }
+  }
+
+  async function generateKey(event: SubmitEvent) {
+    event.preventDefault();
+    submitting = true;
+    log(createLog('ACTION', 'api.public_key.request'));
+    try {
+      const response: PublicKey = await post(
+        Psama.Open.ApiKey,
+        { captchaToken: null, name: name.trim() || null, email: email.trim() || null },
+        undefined,
+        false,
+      );
+      if (!response?.apiKey || !response?.uuid) {
+        // api.ts treats 422 and empty bodies as success; never enter 'revealed' without a key
+        throw { body: { message: '' } };
+      }
+      publicKey = response;
+      view = 'revealed';
+      log(
+        createLog('ACTION', 'api.public_key.success', {
+          uuid: response.uuid,
+          displayPrefix: response.displayPrefix,
+        }),
+      );
+    } catch (err) {
+      errorMessage = extractErrorMessage(err);
+      view = 'error';
+      log(createLog('ACTION', 'api.public_key.failure', { error: errorMessage }));
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div
+  data-testid="public-access-key"
+  class="card border border-surface-200 p-6 min-h-80 flex flex-col"
+>
+  <header class="flex items-center gap-4 mb-4">
+    <i class="fa-solid fa-globe text-3xl text-primary-500"></i>
+    <div>
+      <div class="text-lg font-bold">Public Access Key</div>
+      <div class="text-sm">No account required</div>
+    </div>
+  </header>
+
+  {#if view === 'idle'}
+    <p class="mx-0">
+      A public key grants access to open resources, including aggregate counts for feasibility
+      assessments.
+    </p>
+    {#if enabled}
+      <button class="btn preset-filled-primary-500 my-auto mx-auto" onclick={() => (view = 'form')}>
+        Request Public Key
+      </button>
+    {:else}
+      <p data-testid="public-key-unavailable" class="mx-0 my-auto text-center">
+        Public access keys are not available on this deployment. Please log in for authorized
+        access.
+      </p>
+    {/if}
+  {:else if view === 'form'}
+    <form class="flex flex-col gap-4 flex-1" onsubmit={generateKey}>
+      <div class="label">
+        <label for="public-key-name">Name <span class="text-sm">(optional)</span></label>
+        <input
+          id="public-key-name"
+          class="input"
+          type="text"
+          name="name"
+          maxlength="255"
+          placeholder="Jane Doe"
+          bind:value={name}
+          bind:this={firstField}
+          disabled={submitting}
+        />
+      </div>
+      <div class="label">
+        <label for="public-key-email">Email <span class="text-sm">(optional)</span></label>
+        <input
+          id="public-key-email"
+          class="input"
+          type="email"
+          name="email"
+          maxlength="255"
+          placeholder="you@example.org"
+          aria-describedby="public-key-email-hint"
+          bind:value={email}
+          disabled={submitting}
+        />
+        <span id="public-key-email-hint" class="text-sm">
+          Only used to contact you if there is a problem with your key. No account is created.
+        </span>
+      </div>
+      <!-- CAPTCHA insertion point: the Turnstile widget will mount here and supply the
+           captchaToken sent with the request (currently always null). -->
+      <div class="flex gap-4 justify-center mt-auto">
+        <button type="submit" class="btn preset-filled-primary-500" disabled={submitting}>
+          {#if submitting}
+            <Loading ring size="micro" label="Generating" />
+          {:else}
+            Generate Key
+          {/if}
+        </button>
+        <button
+          type="button"
+          class="btn preset-tonal-primary border border-primary-500 hover:preset-filled-primary-500"
+          onclick={() => (view = 'idle')}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  {:else if view === 'revealed' && publicKey}
+    <aside
+      data-testid="public-key-warning"
+      role="alert"
+      tabindex="-1"
+      bind:this={warning}
+      class="card preset-tonal-warning border border-warning-500 flex items-center gap-4 py-2 px-3 mb-4"
+    >
+      <i class="fa-solid fa-triangle-exclamation text-3xl" aria-hidden="true"></i>
+      <p class="m-0 font-bold">
+        This key is shown only once and cannot be recovered. Copy it now and store it somewhere
+        safe.
+      </p>
+    </aside>
+    <div class="flex items-center gap-2">
+      <code data-testid="public-key-value" class="font-mono text-sm break-all grow"
+        >{publicKey.apiKey}</code
+      >
+      <CopyButton
+        itemToCopy={publicKey.apiKey}
+        class="preset-tonal-primary border border-primary-500 hover:preset-filled-primary-500"
+      />
+    </div>
+    <div class="mt-4">
+      <span class="font-bold">Expires:</span>
+      <span data-testid="public-key-expires">{expires}</span>
+    </div>
+  {:else if view === 'error'}
+    <!-- ErrorAlert has no live region of its own; announce the async failure -->
+    <div role="alert">
+      <ErrorAlert color="warning">{errorMessage}</ErrorAlert>
+    </div>
+    <button class="btn preset-filled-primary-500 my-auto mx-auto" onclick={() => (view = 'form')}>
+      Try Again
+    </button>
+  {/if}
+</div>

--- a/src/lib/components/PublicAccessKey.svelte
+++ b/src/lib/components/PublicAccessKey.svelte
@@ -52,7 +52,9 @@
       const parsed = JSON.parse(message);
       return typeof parsed === 'string' ? parsed : parsed?.message || fallback;
     } catch {
-      return message;
+      // Non-JSON bodies are server/proxy error pages (HTML documents, stack
+      // traces), not messages written for users
+      return message.trimStart().startsWith('<') || message.length > 200 ? fallback : message;
     }
   }
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -44,6 +44,9 @@ const USER = 'psama/user';
 export const Psama = {
   Application: 'psama/application',
   Auth: 'psama/authentication',
+  Open: {
+    ApiKey: 'psama/open/apiKey',
+  },
   Connection: 'psama/connection',
   Priviege: 'psama/privilege',
   StudyAccess: 'psama/studyAccess',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,7 @@ export interface ApiCapability {
 
 export interface ApiPageConfig {
   capabilities: ApiCapability[];
+  publicKeyEnabled?: boolean;
 }
 
 export interface AnalysisConfig {

--- a/src/routes/(picsure)/(public)/api/+page.svelte
+++ b/src/routes/(picsure)/(public)/api/+page.svelte
@@ -7,6 +7,7 @@
   import { log, createLog } from '$lib/logger';
 
   import UserToken from '$lib/components/UserToken.svelte';
+  import PublicAccessKey from '$lib/components/PublicAccessKey.svelte';
   import CodeBlock from '$lib/components/CodeBlock.svelte';
   import TabItem from '$lib/components/TabItem.svelte';
 
@@ -185,26 +186,8 @@
             <UserToken />
           </div>
         {:else}
-          <!-- TODO: Placeholder for the logged-out authentication state; final design and
-               behavior (public access key request) to be defined in an upcoming ticket. -->
-          <div
-            data-testid="public-access-placeholder"
-            class="card border border-surface-200 p-6 basis-[60%] grow-0 min-h-80 flex flex-col"
-          >
-            <header class="flex items-center gap-4 mb-4">
-              <i class="fa-solid fa-globe text-3xl text-primary-500"></i>
-              <div>
-                <div class="text-lg font-bold">Public Access Key</div>
-                <div class="text-sm">No account required</div>
-              </div>
-            </header>
-            <p class="mx-0">
-              A public key grants access to open resources, including aggregate counts for
-              feasibility assessments.
-            </p>
-            <button class="btn preset-filled-primary-500 my-auto mx-auto" disabled
-              >Request Public Key</button
-            >
+          <div class="basis-[60%] grow-0 min-w-0 max-w-full">
+            <PublicAccessKey enabled={branding.apiPage?.publicKeyEnabled ?? false} />
           </div>
         {/if}
         <div id="capabilities" class="flex-1 min-w-64">
@@ -224,6 +207,13 @@
               </li>
             {/each}
           </ul>
+          {#if !loggedIn}
+            <hr class="my-4 border-surface-200" />
+            <p class="mx-0">
+              Looking for authorized access?
+              <a class="anchor" href="/login?redirectTo=/api" data-testid="api-login-link">Login</a>
+            </p>
+          {/if}
         </div>
       </div>
     </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -80,7 +80,8 @@ input[type='search'] {
 }
 
 input[type='search'],
-input[type='text'] {
+input[type='text'],
+input[type='email'] {
   background-color: var(--input-bg-color);
 }
 

--- a/tests/component/PublicAccessKey.test.ts
+++ b/tests/component/PublicAccessKey.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+
+import PublicAccessKey from '$lib/components/PublicAccessKey.svelte';
+
+const { post, log } = vi.hoisted(() => ({ post: vi.fn(), log: vi.fn() }));
+
+vi.mock('$lib/api', () => ({ post }));
+vi.mock('$lib/logger', () => ({
+  log,
+  createLog: (eventType: string, action?: string, metadata?: Record<string, unknown>) => ({
+    event_type: eventType,
+    action,
+    metadata,
+  }),
+}));
+
+const mockKeyResponse = {
+  apiKey: 'picsure_0Zx9AbCdEfGhIjKlMnOpQrStUvWxYz0123456789abc',
+  uuid: '0b6cf65e-6f9e-4a3c-9d0e-1f2a3b4c5d6e',
+  displayPrefix: '0Zx9AbCd',
+  keyType: 'USER',
+  expiresAt: '2026-10-11T12:13:14Z',
+};
+
+async function openForm() {
+  await fireEvent.click(screen.getByRole('button', { name: 'Request Public Key' }));
+}
+
+async function submitForm() {
+  await fireEvent.submit(screen.getByTestId('public-access-key').querySelector('form') as Element);
+}
+
+describe('PublicAccessKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts idle with an enabled request button', () => {
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    const button = screen.getByRole('button', { name: 'Request Public Key' });
+    expect(button).toBeEnabled();
+    expect(screen.getByText('Public Access Key')).toBeInTheDocument();
+    expect(screen.getByText('No account required')).toBeInTheDocument();
+  });
+
+  it('shows unavailable content instead of the button when the deployment disables it', () => {
+    render(PublicAccessKey);
+
+    expect(screen.queryByRole('button', { name: 'Request Public Key' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('public-key-unavailable')).toBeInTheDocument();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('requests an unauthenticated key with a null captcha token and reveals it', async () => {
+    post.mockResolvedValue(mockKeyResponse);
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    expect(post).toHaveBeenCalledWith(
+      'psama/open/apiKey',
+      { captchaToken: null, name: null, email: null },
+      undefined,
+      false,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('public-key-value')).toHaveTextContent(mockKeyResponse.apiKey);
+    });
+    expect(screen.getByTestId('public-key-warning')).toHaveTextContent(
+      'This key is shown only once and cannot be recovered.',
+    );
+    expect(screen.getByTestId('public-key-expires').textContent).not.toBe('');
+  });
+
+  it('sends trimmed name and email when entered', async () => {
+    post.mockResolvedValue(mockKeyResponse);
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await fireEvent.input(screen.getByLabelText(/Name/), {
+      target: { value: '  Jane Doe  ' },
+    });
+    await fireEvent.input(screen.getByLabelText(/Email/), {
+      target: { value: '  researcher@example.org  ' },
+    });
+    await submitForm();
+
+    expect(post).toHaveBeenCalledWith(
+      'psama/open/apiKey',
+      { captchaToken: null, name: 'Jane Doe', email: 'researcher@example.org' },
+      undefined,
+      false,
+    );
+  });
+
+  it('never logs the key value, only uuid and displayPrefix', async () => {
+    post.mockResolvedValue(mockKeyResponse);
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+    await waitFor(() => {
+      expect(screen.getByTestId('public-key-value')).toBeInTheDocument();
+    });
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(log.mock.calls)).not.toContain(mockKeyResponse.apiKey);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'api.public_key.success',
+        metadata: { uuid: mockKeyResponse.uuid, displayPrefix: mockKeyResponse.displayPrefix },
+      }),
+    );
+  });
+
+  it('shows the server message inline on failure and returns to the form on retry', async () => {
+    post.mockRejectedValue({ status: 400, body: { message: 'CAPTCHA verification failed.' } });
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    const alert = await screen.findByTestId('error-alert');
+    expect(alert).toHaveTextContent('CAPTCHA verification failed.');
+    expect(screen.queryByTestId('public-key-value')).not.toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    expect(screen.getByRole('button', { name: 'Generate Key' })).toBeInTheDocument();
+  });
+
+  it('unwraps a JSON error body from the server', async () => {
+    post.mockRejectedValue({
+      status: 400,
+      body: { message: '{"message":"Public key generation is not enabled."}' },
+    });
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    const alert = await screen.findByTestId('error-alert');
+    expect(alert).toHaveTextContent('Public key generation is not enabled.');
+  });
+});

--- a/tests/component/PublicAccessKey.test.ts
+++ b/tests/component/PublicAccessKey.test.ts
@@ -133,6 +133,42 @@ describe('PublicAccessKey', () => {
     expect(screen.getByRole('button', { name: 'Generate Key' })).toBeInTheDocument();
   });
 
+  it('falls back to a generic message when the error body is an HTML page', async () => {
+    post.mockRejectedValue({
+      status: 404,
+      body: {
+        message:
+          '<!doctype html> <html lang="en" class="light" data-theme="picsure"> <head><meta charset="utf-8" /><style>.fa-beat{animation-name:fa-beat}</style></head> <body>Not found</body> </html>',
+      },
+    });
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    const alert = await screen.findByTestId('error-alert');
+    expect(alert).toHaveTextContent(
+      'Unable to generate a public access key. Please try again later.',
+    );
+    expect(alert.textContent).not.toContain('<');
+  });
+
+  it('falls back to a generic message when the error body is overlong plain text', async () => {
+    post.mockRejectedValue({
+      status: 500,
+      body: { message: 'java.lang.NullPointerException at '.padEnd(500, 'x') },
+    });
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    const alert = await screen.findByTestId('error-alert');
+    expect(alert).toHaveTextContent(
+      'Unable to generate a public access key. Please try again later.',
+    );
+  });
+
   it('unwraps a JSON error body from the server', async () => {
     post.mockRejectedValue({
       status: 400,

--- a/tests/end-to-end/api/public-key.test.ts
+++ b/tests/end-to-end/api/public-key.test.ts
@@ -1,0 +1,140 @@
+import { expect, type Page, type Route } from '@playwright/test';
+import { test, mockApiSuccess } from '../custom-context';
+
+const apiKeyPath = '*/**/psama/open/apiKey';
+const mockKeyResponse = {
+  apiKey: 'picsure_0Zx9AbCdEfGhIjKlMnOpQrStUvWxYz0123456789abc',
+  uuid: '0b6cf65e-6f9e-4a3c-9d0e-1f2a3b4c5d6e',
+  displayPrefix: '0Zx9AbCd',
+  keyType: 'USER',
+  expiresAt: '2026-10-11T12:13:14Z',
+};
+
+test.use({ storageState: 'tests/end-to-end/.auth/unauthenticated.json' });
+
+// Clicks that land before Svelte hydration are silently dropped, so retry until the form opens
+async function openForm(page: Page) {
+  await expect(async () => {
+    await page.getByRole('button', { name: 'Request Public Key' }).click({ timeout: 2000 });
+    await expect(page.getByRole('button', { name: 'Generate Key' })).toBeVisible({ timeout: 2000 });
+  }).toPass({ timeout: 15000 });
+}
+
+test.describe('Public access key generation', () => {
+  test('Logged-out api page shows the card with an enabled request button', async ({ page }) => {
+    // Given
+    await page.goto('/api');
+
+    // When
+    const card = page.getByTestId('public-access-key');
+
+    // Then
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Public Access Key');
+    await expect(card).toContainText('No account required');
+    await expect(card.getByRole('button', { name: 'Request Public Key' })).toBeEnabled();
+    await expect(page.getByTestId('api-login-link')).toHaveAttribute(
+      'href',
+      '/login?redirectTo=/api',
+    );
+  });
+
+  test('Generates and reveals a key with copy button and one-time warning', async ({
+    page,
+    context,
+  }) => {
+    // Given
+    await mockApiSuccess(context, apiKeyPath, mockKeyResponse);
+    await page.goto('/api');
+
+    // When
+    await openForm(page);
+    await page.getByRole('button', { name: 'Generate Key' }).click();
+
+    // Then
+    await expect(page.getByTestId('public-key-value')).toHaveText(mockKeyResponse.apiKey);
+    await expect(page.getByTestId('copy-btn')).toBeVisible();
+    await expect(page.getByTestId('public-key-warning')).toContainText(
+      'This key is shown only once and cannot be recovered.',
+    );
+    await expect(page.getByTestId('public-key-expires')).not.toBeEmpty();
+  });
+
+  test('Sends no Authorization header and a null captcha token', async ({ page, context }) => {
+    // Given
+    let headers: Record<string, string> | undefined;
+    let body: string | null | undefined;
+    await context.route(apiKeyPath, async (route: Route) => {
+      headers = route.request().headers();
+      body = route.request().postData();
+      await route.fulfill({ json: mockKeyResponse });
+    });
+    await page.goto('/api');
+    // A token appearing in localStorage after load (login in another tab, leftover expired
+    // token) must NOT be attached: api.ts reads localStorage at request time and a stale
+    // token 401s this public endpoint server-side
+    await page.evaluate(() => localStorage.setItem('token', 'stale.jwt.value'));
+
+    // When
+    await openForm(page);
+    await page.getByLabel('Email (optional)').fill('researcher@example.org');
+    await page.getByRole('button', { name: 'Generate Key' }).click();
+    await expect(page.getByTestId('public-key-value')).toBeVisible();
+
+    // Then
+    expect(headers?.['authorization']).toBeUndefined();
+    expect(headers?.['request-source']).toBe('Open');
+    expect(JSON.parse(body || '{}')).toEqual({
+      captchaToken: null,
+      name: null,
+      email: 'researcher@example.org',
+    });
+  });
+
+  test('Shows an inline error on failure and allows retry', async ({ page, context }) => {
+    // Given
+    await context.route(apiKeyPath, (route: Route) =>
+      route.fulfill({
+        status: 400,
+        contentType: 'text/plain',
+        body: 'Public key generation is not enabled.',
+      }),
+    );
+    await page.goto('/api');
+
+    // When
+    await openForm(page);
+    await page.getByRole('button', { name: 'Generate Key' }).click();
+
+    // Then
+    const errorAlert = page.getByTestId('public-access-key').getByTestId('error-alert');
+    await expect(errorAlert).toBeVisible();
+    await expect(errorAlert).toContainText('Public key generation is not enabled.');
+    await expect(page.getByTestId('public-key-value')).not.toBeVisible();
+
+    // When
+    await page.getByRole('button', { name: 'Try Again' }).click();
+
+    // Then
+    await expect(page.getByRole('button', { name: 'Generate Key' })).toBeVisible();
+  });
+
+  test('Cancel returns to the idle state without a request', async ({ page, context }) => {
+    // Given
+    let requestCount = 0;
+    await context.route(apiKeyPath, async (route: Route) => {
+      requestCount++;
+      await route.fulfill({ json: mockKeyResponse });
+    });
+    await page.goto('/api');
+
+    // When
+    await openForm(page);
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    // Then
+    await expect(page.getByRole('button', { name: 'Request Public Key' })).toBeEnabled();
+    await expect(page.getByTestId('public-key-value')).not.toBeVisible();
+    expect(requestCount).toBe(0);
+  });
+});

--- a/tests/end-to-end/api/public-key.test.ts
+++ b/tests/end-to-end/api/public-key.test.ts
@@ -70,13 +70,14 @@ test.describe('Public access key generation', () => {
       await route.fulfill({ json: mockKeyResponse });
     });
     await page.goto('/api');
-    // A token appearing in localStorage after load (login in another tab, leftover expired
-    // token) must NOT be attached: api.ts reads localStorage at request time and a stale
-    // token 401s this public endpoint server-side
-    await page.evaluate(() => localStorage.setItem('token', 'stale.jwt.value'));
 
     // When
     await openForm(page);
+    // A token appearing in localStorage after load (login in another tab, leftover expired
+    // token) must NOT be attached: api.ts reads localStorage at request time and a stale
+    // token 401s this public endpoint server-side. Set it only after the form is open —
+    // if hydration sees the token first, the page renders logged-in and the form never exists.
+    await page.evaluate(() => localStorage.setItem('token', 'stale.jwt.value'));
     await page.getByLabel('Email (optional)').fill('researcher@example.org');
     await page.getByRole('button', { name: 'Generate Key' }).click();
     await expect(page.getByTestId('public-key-value')).toBeVisible();

--- a/tests/end-to-end/api/test.ts
+++ b/tests/end-to-end/api/test.ts
@@ -145,6 +145,7 @@ test.describe('API page', () => {
     await expect(page.getByText('Personal Access Token').first()).toBeVisible();
     await expect(page.getByText('Login confirmed')).toBeVisible();
     await expect(page.locator('i.fa-user-shield')).toBeVisible();
+    await expect(page.getByTestId('public-access-key')).not.toBeVisible();
   });
 
   test('Has expected content', async ({ page }) => {
@@ -359,12 +360,12 @@ test.describe('API page logged out', () => {
     await expect(navLink).toHaveAttribute('aria-current', 'page');
   });
 
-  test('Shows public access placeholder instead of personal access token', async ({ page }) => {
+  test('Shows public access key card instead of personal access token', async ({ page }) => {
     // Given
     await page.goto('/api');
 
     // Then
-    await expect(page.getByTestId('public-access-placeholder')).toBeVisible();
+    await expect(page.getByTestId('public-access-key')).toBeVisible();
     await expect(page.locator('#user-token')).not.toBeVisible();
   });
 


### PR DESCRIPTION
## What this does

Replaces the logged-out "Public Access Key" placeholder card on `/api` with a working self-service key flow: request button → optional name/email form → one-time key reveal with copy button.

- **`PublicAccessKey.svelte`** — idle / form / revealed / error state machine.
  - Calls `POST psama/open/apiKey` with `authenticate: false` so no `Authorization` header can ever attach (a stale token 401s this public endpoint server-side; an e2e test injects a stale token post-load to pin this).
  - See-once reveal: `role="alert"` + focused warning, copy via the existing `CopyButton`; the key is never logged (only `uuid` + `displayPrefix` go to telemetry) and never stored.
  - Response shape is validated before entering the revealed state (`api.ts` treats 422/empty bodies as success).
  - CAPTCHA: single marked insertion point; `captchaToken` is `null` until the Turnstile widget lands.
- **Deployment gate** — new `branding.apiPage.publicKeyEnabled` config. Absent/false shows explanatory "not available on this deployment" content instead of a doomed button (the backend's `API_KEY_GENERATION_ENABLED` flag, default off, remains the authoritative gate). The checked-in dev config enables it so the e2e flow tests run.
- Adds the "Looking for authorized access? Login" link under the capabilities list (logged-out only).
- `app.css`: `input[type='email']` now gets the same white background as text/search inputs (also affects the admin UserForm email field, which had the same inconsistency).

## Depends on

PSAMA `POST /open/apiKey` (branch `feat/open-access-api-keys`, PR to follow). Safe to merge independently: the card is config-gated and the integration branch doesn't ship until the API-page epic lands.

## Testing

- Component: 9 specs (state machine, request shape, trimmed fields, no-key-in-logs, error unwrapping, disabled-deployment state)
- e2e: 6 specs incl. the stale-token/no-Authorization-header invariant and a cancel-fires-no-request check (need CI — Playwright browsers not installed locally)
- `pnpm run format` / `lint` / `check` clean