### PR TITLE
[ALS-12222] Friendly fallback for unreadable public key errors

### DIFF
--- a/src/lib/components/PublicAccessKey.svelte
+++ b/src/lib/components/PublicAccessKey.svelte
@@ -52,7 +52,9 @@
       const parsed = JSON.parse(message);
       return typeof parsed === 'string' ? parsed : parsed?.message || fallback;
     } catch {
-      return message;
+      // Non-JSON bodies are server/proxy error pages (HTML documents, stack
+      // traces), not messages written for users
+      return message.trimStart().startsWith('<') || message.length > 200 ? fallback : message;
     }
   }
 

--- a/tests/component/PublicAccessKey.test.ts
+++ b/tests/component/PublicAccessKey.test.ts
@@ -133,6 +133,42 @@ describe('PublicAccessKey', () => {
     expect(screen.getByRole('button', { name: 'Generate Key' })).toBeInTheDocument();
   });
 
+  it('falls back to a generic message when the error body is an HTML page', async () => {
+    post.mockRejectedValue({
+      status: 404,
+      body: {
+        message:
+          '<!doctype html> <html lang="en" class="light" data-theme="picsure"> <head><meta charset="utf-8" /><style>.fa-beat{animation-name:fa-beat}</style></head> <body>Not found</body> </html>',
+      },
+    });
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    const alert = await screen.findByTestId('error-alert');
+    expect(alert).toHaveTextContent(
+      'Unable to generate a public access key. Please try again later.',
+    );
+    expect(alert.textContent).not.toContain('<');
+  });
+
+  it('falls back to a generic message when the error body is overlong plain text', async () => {
+    post.mockRejectedValue({
+      status: 500,
+      body: { message: 'java.lang.NullPointerException at '.padEnd(500, 'x') },
+    });
+    render(PublicAccessKey, { props: { enabled: true } });
+
+    await openForm();
+    await submitForm();
+
+    const alert = await screen.findByTestId('error-alert');
+    expect(alert).toHaveTextContent(
+      'Unable to generate a public access key. Please try again later.',
+    );
+  });
+
   it('unwraps a JSON error body from the server', async () => {
     post.mockRejectedValue({
       status: 400,

--- a/tests/end-to-end/api/public-key.test.ts
+++ b/tests/end-to-end/api/public-key.test.ts
@@ -70,13 +70,14 @@ test.describe('Public access key generation', () => {
       await route.fulfill({ json: mockKeyResponse });
     });
     await page.goto('/api');
-    // A token appearing in localStorage after load (login in another tab, leftover expired
-    // token) must NOT be attached: api.ts reads localStorage at request time and a stale
-    // token 401s this public endpoint server-side
-    await page.evaluate(() => localStorage.setItem('token', 'stale.jwt.value'));
 
     // When
     await openForm(page);
+    // A token appearing in localStorage after load (login in another tab, leftover expired
+    // token) must NOT be attached: api.ts reads localStorage at request time and a stale
+    // token 401s this public endpoint server-side. Set it only after the form is open —
+    // if hydration sees the token first, the page renders logged-in and the form never exists.
+    await page.evaluate(() => localStorage.setItem('token', 'stale.jwt.value'));
     await page.getByLabel('Email (optional)').fill('researcher@example.org');
     await page.getByRole('button', { name: 'Generate Key' }).click();
     await expect(page.getByTestId('public-key-value')).toBeVisible();


### PR DESCRIPTION
## Summary
When the public access key request fails and the response body is not JSON — e.g. a proxy or app-shell HTML page, or a raw stack trace — the error view rendered the entire body verbatim, filling the card with HTML soup.

`extractErrorMessage` in `PublicAccessKey.svelte` now falls back to the generic "Unable to generate a public access key. Please try again later." when a non-JSON body starts with markup or exceeds 200 characters. Short plaintext messages written by the server (e.g. "CAPTCHA verification failed.") still display verbatim, and JSON bodies unwrap exactly as before.

## Testing
- Two new component tests in `tests/component/PublicAccessKey.test.ts` (HTML document body, overlong stack-trace body), written first and confirmed failing against the old code; all 9 tests in the file pass.
- Reproduced manually: clicking Generate Key against a dev server with no backend now shows the friendly message instead of the rendered app shell.