### PR TITLE
[ALS-12357] Open-access API key plumbing: server-side proxy and admin key management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ LOGGING_API_KEY=
 # PLATFORM API key attached to anonymous open-access requests by the server-side proxy.
 # Mint one via the PSAMA admin API key endpoints. Never expose it with a VITE_ prefix.
 PICSURE_PLATFORM_API_KEY=
+# Internal origin the open-access proxy uses to reach the PIC-SURE API (no trailing slash).
+# Defaults to http://localhost; multi-host deployments must point this at the API host.
+PICSURE_INTERNAL_API_ORIGIN=
 
 ### Auth Providers
 # VITE_AUTH_PROVIDER_MODULE is the prefix for any authorization providers you want to use.

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ VITE_RESOURCE_VIZ=
 ### Server Only Resources
 RESOURCE_LOG=
 LOGGING_API_KEY=
+# PLATFORM API key attached to anonymous open-access requests by the server-side proxy.
+# Mint one via the PSAMA admin API key endpoints. Never expose it with a VITE_ prefix.
+PICSURE_PLATFORM_API_KEY=
 
 ### Auth Providers
 # VITE_AUTH_PROVIDER_MODULE is the prefix for any authorization providers you want to use.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
     "test": "pnpm run test:vitest && pnpm run test:integration",
-    "test:vitest": "vitest run tests/unit tests/component",
+    "test:vitest": "vitest run tests/unit tests/component src/routes/api/v1/open",
     "test:unit": "vitest run tests/unit",
     "test:component": "vitest run tests/component",
     "test:integration": "playwright test",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@ import { error, type NumericRange } from '@sveltejs/kit';
 import { logout, login } from '$lib/stores/User';
 import { browser } from '$app/environment';
 import { log, createLog, getSessionId } from '$lib/logger';
+import { Internal } from '$lib/paths';
 
 const BEARER = 'Bearer ';
 
@@ -34,6 +35,7 @@ async function send({
     opts.headers = { ...opts.headers, ...headers };
   }
 
+  let requestPath = `/${path}`;
   if (browser) {
     const token = authenticate ? localStorage.getItem('token') : null;
     if (token) {
@@ -41,11 +43,18 @@ async function send({
       opts.headers['request-source'] = 'Authorized';
     } else {
       opts.headers['request-source'] = 'Open';
+      // Any token-less data request goes through the SvelteKit server proxy, which attaches the
+      // deployment's platform API key server-side so it never reaches the browser. This covers
+      // both "no token exists" and authenticate:false (a logged-in user querying the open
+      // variant). Non-picsure paths (e.g. psama key generation) are never proxied.
+      if (path.startsWith('picsure/')) {
+        requestPath = `${Internal.OpenProxy}/${path}`;
+      }
     }
     opts.headers['X-Session-Id'] = getSessionId();
   }
 
-  const res = await fetch(`${window.location.origin}/${path}`, opts);
+  const res = await fetch(`${window.location.origin}${requestPath}`, opts);
 
   return await handleResponse(res);
 }

--- a/src/lib/assets/configuration.json
+++ b/src/lib/assets/configuration.json
@@ -17,6 +17,7 @@
       "privilege": "ADMIN",
       "links": [
         { "title": "Manage Users", "url": "/admin/users" },
+        { "title": "API Keys", "url": "/admin/api-keys" },
         { "title": "Configuration", "url": "/admin/configuration" }
       ]
     },

--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -28,16 +28,20 @@
     goto(`/login?redirectTo=${page.url.pathname}`);
   }
 
+  const isActivePath = $derived((path: string) => {
+    return page.url.pathname === path || page.url.pathname.startsWith(`${path}/`);
+  });
+
   let currentPage = $derived((route: Route) => {
     if (route.children) {
       for (const child of route.children) {
-        if (page.url.pathname.includes(child.path)) {
+        if (isActivePath(child.path)) {
           return 'page';
         }
       }
       return undefined;
     }
-    return page.url.pathname.includes(route.path) ? 'page' : undefined;
+    return isActivePath(route.path) ? 'page' : undefined;
   });
 
   onMount(async () => {

--- a/src/lib/components/admin/api-key/ApiKeyTable.svelte
+++ b/src/lib/components/admin/api-key/ApiKeyTable.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { TableHandler, type State } from '@vincjo/datatables/server';
 
   import RemoteTable from '$lib/components/datatable/RemoteTable.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import ApiKeyStatus from '$lib/components/admin/api-key/cell/ApiKeyStatus.svelte';
-  import ApiKeyType from '$lib/components/admin/api-key/cell/ApiKeyType.svelte';
   import ApiKeyActions from '$lib/components/admin/api-key/cell/ApiKeyActions.svelte';
 
   import { loadApiKeys, listVersion } from '$lib/stores/ApiKeys';
@@ -16,7 +15,6 @@
   interface ApiKeyRow {
     uuid: string;
     prefix: string;
-    keyType: string;
     name: string;
     email: string;
     created: string;
@@ -25,11 +23,12 @@
     status: string;
   }
 
+  const { keyType, tableName }: { keyType: 'USER' | 'PLATFORM'; tableName: string } = $props();
+
   let loadError = $state('');
 
   const columns = [
     { dataElement: 'prefix', label: 'Key' },
-    { dataElement: 'keyType', label: 'Type', class: 'w-28' },
     { dataElement: 'name', label: 'Name' },
     { dataElement: 'email', label: 'Email' },
     { dataElement: 'created', label: 'Created' },
@@ -40,23 +39,24 @@
   ];
 
   const cellOverides = {
-    keyType: ApiKeyType,
     status: ApiKeyStatus,
     uuid: ApiKeyActions,
   };
 
-  const handler = new TableHandler<ApiKeyRow>([], { rowsPerPage: getDefaultRows('ApiKeys') });
+  // tableName is a constant per instance; read it once for the initial page size
+  const handler = new TableHandler<ApiKeyRow>([], {
+    rowsPerPage: untrack(() => getDefaultRows(tableName)),
+  });
 
   handler.load(async (state: State) => {
     try {
       loadError = '';
-      const page = await loadApiKeys(state.currentPage - 1, state.rowsPerPage);
+      const page = await loadApiKeys(state.currentPage - 1, state.rowsPerPage, keyType);
       state.setTotalRows(page.totalCount);
       return page.keys.map(
         (key): ApiKeyRow => ({
           uuid: key.uuid,
           prefix: `picsure_${key.displayPrefix}…`,
-          keyType: key.keyType,
           name: key.name || '',
           email: key.email || '',
           created: formatInstant(key.createdAt),
@@ -82,5 +82,5 @@
 {#if loadError}
   <ErrorAlert title="API Error" data-testid="api-key-list-error">{loadError}</ErrorAlert>
 {:else}
-  <RemoteTable tableName="ApiKeys" {handler} {columns} {cellOverides} tableAuto={false} />
+  <RemoteTable {tableName} {handler} {columns} {cellOverides} tableAuto={false} />
 {/if}

--- a/src/lib/components/admin/api-key/ApiKeyTable.svelte
+++ b/src/lib/components/admin/api-key/ApiKeyTable.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { TableHandler, type State } from '@vincjo/datatables/server';
+
+  import RemoteTable from '$lib/components/datatable/RemoteTable.svelte';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import ApiKeyStatus from '$lib/components/admin/api-key/cell/ApiKeyStatus.svelte';
+  import ApiKeyType from '$lib/components/admin/api-key/cell/ApiKeyType.svelte';
+  import ApiKeyActions from '$lib/components/admin/api-key/cell/ApiKeyActions.svelte';
+
+  import { loadApiKeys, listVersion } from '$lib/stores/ApiKeys';
+  import { getApiKeyStatus, formatInstant, extractApiError } from '$lib/models/ApiKey';
+  import { getDefaultRows } from '$lib/components/datatable/stores';
+  import { subscribeOnChange } from '$lib/utilities/Subscribers';
+
+  interface ApiKeyRow {
+    uuid: string;
+    prefix: string;
+    keyType: string;
+    name: string;
+    email: string;
+    created: string;
+    expires: string;
+    lastUsed: string;
+    status: string;
+  }
+
+  let loadError = $state('');
+
+  const columns = [
+    { dataElement: 'prefix', label: 'Key' },
+    { dataElement: 'keyType', label: 'Type', class: 'w-28' },
+    { dataElement: 'name', label: 'Name' },
+    { dataElement: 'email', label: 'Email' },
+    { dataElement: 'created', label: 'Created' },
+    { dataElement: 'expires', label: 'Expires' },
+    { dataElement: 'lastUsed', label: 'Last Used' },
+    { dataElement: 'status', label: 'Status', class: 'w-24 text-center' },
+    { dataElement: 'uuid', label: 'Actions', class: 'w-32 text-center' },
+  ];
+
+  const cellOverides = {
+    keyType: ApiKeyType,
+    status: ApiKeyStatus,
+    uuid: ApiKeyActions,
+  };
+
+  const handler = new TableHandler<ApiKeyRow>([], { rowsPerPage: getDefaultRows('ApiKeys') });
+
+  handler.load(async (state: State) => {
+    try {
+      loadError = '';
+      const page = await loadApiKeys(state.currentPage - 1, state.rowsPerPage);
+      state.setTotalRows(page.totalCount);
+      return page.keys.map(
+        (key): ApiKeyRow => ({
+          uuid: key.uuid,
+          prefix: `picsure_${key.displayPrefix}…`,
+          keyType: key.keyType,
+          name: key.name || '',
+          email: key.email || '',
+          created: formatInstant(key.createdAt),
+          expires: formatInstant(key.expiresAt, 'Never'),
+          lastUsed: formatInstant(key.lastUsedAt, 'Never'),
+          status: getApiKeyStatus(key),
+        }),
+      );
+    } catch (error) {
+      loadError = extractApiError(error);
+      state.setTotalRows(0);
+      return [];
+    }
+  });
+
+  onMount(() => {
+    handler.invalidate();
+  });
+  const unsubscribe = subscribeOnChange(listVersion, () => handler.invalidate());
+  onDestroy(unsubscribe);
+</script>
+
+{#if loadError}
+  <ErrorAlert title="API Error" data-testid="api-key-list-error">{loadError}</ErrorAlert>
+{:else}
+  <RemoteTable tableName="ApiKeys" {handler} {columns} {cellOverides} tableAuto={false} />
+{/if}

--- a/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
+++ b/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
@@ -25,8 +25,9 @@
   let minted: MintedPlatformKey | null = $state(null);
 
   const minExpiryDate = (() => {
+    // keys expire at 00:00 UTC, so the earliest selectable day must be computed in UTC too
     const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
     return tomorrow.toISOString().slice(0, 10);
   })();
 
@@ -132,7 +133,7 @@
           <span class="font-semibold">Expiration:</span>
           <label class="flex items-center gap-2">
             <input type="radio" class="radio" bind:group={expiryMode} value="default" />
-            <span>Default (1 year)</span>
+            <span>Default (server policy)</span>
           </label>
           <label class="flex items-center gap-2">
             <input type="radio" class="radio" bind:group={expiryMode} value="date" />

--- a/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
+++ b/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
@@ -12,13 +12,14 @@
     type MintedPlatformKey,
   } from '$lib/models/ApiKey';
 
-  let formOpen = $state(false);
-  let revealOpen = $state(false);
+  let open = $state(false);
   let name = $state('');
   let email = $state('');
   let expiryDate = $state('');
   let mintError = $state('');
   let isSubmitting = $state(false);
+  // once set, the same modal swaps from the form to the see-once reveal; keeping it a single
+  // Modal instance avoids a second dialog whose layer collides with the closing form dialog
   let minted: MintedPlatformKey | null = $state(null);
 
   const minExpiryDate = (() => {
@@ -27,11 +28,23 @@
     return tomorrow.toISOString().slice(0, 10);
   })();
 
-  function resetForm() {
+  function clearState() {
     name = '';
     email = '';
     expiryDate = '';
     mintError = '';
+    minted = null;
+  }
+
+  // Done/Cancel close explicitly and clear here; this backstop covers escape and click-outside
+  // (which don't route through those buttons) so the plaintext key never lingers after any close
+  $effect(() => {
+    if (!open) clearState();
+  });
+
+  function close() {
+    open = false;
+    clearState();
   }
 
   async function submit(event: SubmitEvent) {
@@ -42,108 +55,92 @@
     mintError = '';
     try {
       minted = await mintPlatformKey(toPlatformKeyRequest(name, email, expiryDate));
-      formOpen = false;
-      revealOpen = true;
-      resetForm();
     } catch (error) {
       mintError = extractApiError(error);
     } finally {
       isSubmitting = false;
     }
   }
-
-  function acknowledge() {
-    revealOpen = false;
-    minted = null;
-  }
 </script>
 
 <Modal
-  bind:open={formOpen}
+  bind:open
   data-testid="mint-platform-key"
-  title="Mint Platform API Key"
+  title={minted ? 'Platform API Key Created' : 'Mint Platform API Key'}
   width="w-full max-w-xl"
   disabled={!$isTopAdmin}
-  onclose={resetForm}
+  closeable={!minted && !isSubmitting}
   triggerBase="btn preset-tonal-primary border border-primary-500 hover:preset-filled-primary-500"
 >
   {#snippet trigger()}+ Mint Platform Key{/snippet}
-  <form onsubmit={submit} class="mt-4">
-    {#if mintError}
-      <ErrorAlert title="Unable to mint key" data-testid="mint-key-error">
-        <p>{mintError}</p>
-      </ErrorAlert>
-    {/if}
-    <fieldset class="grid gap-4 my-3" disabled={isSubmitting}>
-      <label class="label required">
-        <span>Name:</span>
-        <input type="text" bind:value={name} class="input" required maxlength="255" />
-      </label>
-      <label class="label required">
-        <span>Email:</span>
-        <input type="email" bind:value={email} class="input" required maxlength="255" />
-      </label>
-      <label class="label">
-        <span>Expiration date (optional, expires at 00:00 UTC):</span>
-        <input type="date" bind:value={expiryDate} class="input" min={minExpiryDate} />
-      </label>
-    </fieldset>
-    <footer class="flex justify-end space-x-2 mt-6">
-      <button
-        type="button"
-        class="btn border preset-tonal-primary hover:preset-filled-primary-500"
-        onclick={() => {
-          formOpen = false;
-          resetForm();
-        }}
+  {#if minted}
+    <div data-testid="mint-key-reveal">
+      <div
+        role="alert"
+        data-testid="minted-key-warning"
+        class="card preset-tonal-warning border border-warning-500 p-3 my-4 font-bold"
       >
-        Cancel
-      </button>
-      <button type="submit" class="btn preset-filled-primary-500" disabled={isSubmitting}>
-        {isSubmitting ? 'Minting…' : 'Mint Key'}
-      </button>
-    </footer>
-  </form>
+        This key is shown only once and cannot be recovered. Copy it now and store it securely.
+      </div>
+      <div class="flex items-center gap-2 my-4">
+        <code data-testid="minted-api-key" class="code font-mono break-all p-2 grow"
+          >{minted.apiKey}</code
+        >
+        <CopyButton
+          itemToCopy={minted.apiKey}
+          data-testid="copy-minted-api-key"
+          class="preset-filled-primary-500"
+        />
+      </div>
+      <p class="my-2">
+        Key prefix: <code class="code">picsure_{minted.displayPrefix}…</code>
+        &middot; Expires: {formatInstant(minted.expiresAt, 'Never')}
+      </p>
+      <footer class="flex justify-end mt-6">
+        <button
+          type="button"
+          data-testid="done-minted-key"
+          class="btn preset-filled-primary-500"
+          onclick={close}
+        >
+          Done
+        </button>
+      </footer>
+    </div>
+  {:else}
+    <form onsubmit={submit} class="mt-4">
+      {#if mintError}
+        <ErrorAlert title="Unable to mint key" data-testid="mint-key-error">
+          <p>{mintError}</p>
+        </ErrorAlert>
+      {/if}
+      <fieldset class="grid gap-4 my-3" disabled={isSubmitting}>
+        <label class="label required">
+          <span>Name:</span>
+          <input type="text" bind:value={name} class="input" required maxlength="255" />
+        </label>
+        <label class="label required">
+          <span>Email:</span>
+          <input type="email" bind:value={email} class="input" required maxlength="255" />
+        </label>
+        <label class="label">
+          <span>Expiration date (optional, expires at 00:00 UTC):</span>
+          <input type="date" bind:value={expiryDate} class="input" min={minExpiryDate} />
+        </label>
+      </fieldset>
+      <footer class="flex justify-end space-x-2 mt-6">
+        <button
+          type="button"
+          class="btn border preset-tonal-primary hover:preset-filled-primary-500"
+          onclick={close}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn preset-filled-primary-500" disabled={isSubmitting}>
+          {isSubmitting ? 'Minting…' : 'Mint Key'}
+        </button>
+      </footer>
+    </form>
+  {/if}
 </Modal>
-
-{#if minted}
-  <Modal
-    bind:open={revealOpen}
-    data-testid="mint-key-reveal"
-    title="Platform API Key Created"
-    width="w-full max-w-xl"
-    closeable={false}
-  >
-    <div
-      role="alert"
-      data-testid="minted-key-warning"
-      class="card preset-tonal-warning border border-warning-500 p-3 my-4 font-bold"
-    >
-      This key is shown only once and cannot be recovered. Copy it now and store it securely.
-    </div>
-    <div class="flex items-center gap-2 my-4">
-      <code data-testid="minted-api-key" class="code font-mono break-all p-2 grow"
-        >{minted.apiKey}</code
-      >
-      <CopyButton
-        itemToCopy={minted.apiKey}
-        data-testid="copy-minted-api-key"
-        class="preset-filled-primary-500"
-      />
-    </div>
-    <p class="my-2">
-      Key prefix: <code class="code">picsure_{minted.displayPrefix}…</code>
-      &middot; Expires: {formatInstant(minted.expiresAt, 'Never')}
-    </p>
-    <footer class="flex justify-end mt-6">
-      <button
-        type="button"
-        data-testid="acknowledge-minted-key"
-        class="btn preset-filled-primary-500"
-        onclick={acknowledge}
-      >
-        I've copied the key
-      </button>
-    </footer>
-  </Modal>
-{/if}

--- a/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
+++ b/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import Modal from '$lib/components/Modal.svelte';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import CopyButton from '$lib/components/buttons/CopyButton.svelte';
+
+  import { isTopAdmin } from '$lib/stores/User';
+  import { mintPlatformKey } from '$lib/stores/ApiKeys';
+  import {
+    extractApiError,
+    formatInstant,
+    toPlatformKeyRequest,
+    type MintedPlatformKey,
+  } from '$lib/models/ApiKey';
+
+  let formOpen = $state(false);
+  let revealOpen = $state(false);
+  let name = $state('');
+  let email = $state('');
+  let expiryDate = $state('');
+  let mintError = $state('');
+  let isSubmitting = $state(false);
+  let minted: MintedPlatformKey | null = $state(null);
+
+  const minExpiryDate = (() => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow.toISOString().slice(0, 10);
+  })();
+
+  function resetForm() {
+    name = '';
+    email = '';
+    expiryDate = '';
+    mintError = '';
+  }
+
+  async function submit(event: SubmitEvent) {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    isSubmitting = true;
+    mintError = '';
+    try {
+      minted = await mintPlatformKey(toPlatformKeyRequest(name, email, expiryDate));
+      formOpen = false;
+      revealOpen = true;
+      resetForm();
+    } catch (error) {
+      mintError = extractApiError(error);
+    } finally {
+      isSubmitting = false;
+    }
+  }
+
+  function acknowledge() {
+    revealOpen = false;
+    minted = null;
+  }
+</script>
+
+<Modal
+  bind:open={formOpen}
+  data-testid="mint-platform-key"
+  title="Mint Platform API Key"
+  width="w-full max-w-xl"
+  disabled={!$isTopAdmin}
+  onclose={resetForm}
+  triggerBase="btn preset-tonal-primary border border-primary-500 hover:preset-filled-primary-500"
+>
+  {#snippet trigger()}+ Mint Platform Key{/snippet}
+  <form onsubmit={submit} class="mt-4">
+    {#if mintError}
+      <ErrorAlert title="Unable to mint key" data-testid="mint-key-error">
+        <p>{mintError}</p>
+      </ErrorAlert>
+    {/if}
+    <fieldset class="grid gap-4 my-3" disabled={isSubmitting}>
+      <label class="label required">
+        <span>Name:</span>
+        <input type="text" bind:value={name} class="input" required maxlength="255" />
+      </label>
+      <label class="label required">
+        <span>Email:</span>
+        <input type="email" bind:value={email} class="input" required maxlength="255" />
+      </label>
+      <label class="label">
+        <span>Expiration date (optional, expires at 00:00 UTC):</span>
+        <input type="date" bind:value={expiryDate} class="input" min={minExpiryDate} />
+      </label>
+    </fieldset>
+    <footer class="flex justify-end space-x-2 mt-6">
+      <button
+        type="button"
+        class="btn border preset-tonal-primary hover:preset-filled-primary-500"
+        onclick={() => {
+          formOpen = false;
+          resetForm();
+        }}
+      >
+        Cancel
+      </button>
+      <button type="submit" class="btn preset-filled-primary-500" disabled={isSubmitting}>
+        {isSubmitting ? 'Minting…' : 'Mint Key'}
+      </button>
+    </footer>
+  </form>
+</Modal>
+
+{#if minted}
+  <Modal
+    bind:open={revealOpen}
+    data-testid="mint-key-reveal"
+    title="Platform API Key Created"
+    width="w-full max-w-xl"
+    closeable={false}
+  >
+    <div
+      role="alert"
+      data-testid="minted-key-warning"
+      class="card preset-tonal-warning border border-warning-500 p-3 my-4 font-bold"
+    >
+      This key is shown only once and cannot be recovered. Copy it now and store it securely.
+    </div>
+    <div class="flex items-center gap-2 my-4">
+      <code data-testid="minted-api-key" class="code font-mono break-all p-2 grow"
+        >{minted.apiKey}</code
+      >
+      <CopyButton
+        itemToCopy={minted.apiKey}
+        data-testid="copy-minted-api-key"
+        class="preset-filled-primary-500"
+      />
+    </div>
+    <p class="my-2">
+      Key prefix: <code class="code">picsure_{minted.displayPrefix}…</code>
+      &middot; Expires: {formatInstant(minted.expiresAt, 'Never')}
+    </p>
+    <footer class="flex justify-end mt-6">
+      <button
+        type="button"
+        data-testid="acknowledge-minted-key"
+        class="btn preset-filled-primary-500"
+        onclick={acknowledge}
+      >
+        I've copied the key
+      </button>
+    </footer>
+  </Modal>
+{/if}

--- a/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
+++ b/src/lib/components/admin/api-key/MintPlatformKeyModal.svelte
@@ -10,11 +10,13 @@
     formatInstant,
     toPlatformKeyRequest,
     type MintedPlatformKey,
+    type PlatformKeyExpiry,
   } from '$lib/models/ApiKey';
 
   let open = $state(false);
   let name = $state('');
   let email = $state('');
+  let expiryMode: PlatformKeyExpiry['mode'] = $state('default');
   let expiryDate = $state('');
   let mintError = $state('');
   let isSubmitting = $state(false);
@@ -31,6 +33,7 @@
   function clearState() {
     name = '';
     email = '';
+    expiryMode = 'default';
     expiryDate = '';
     mintError = '';
     minted = null;
@@ -53,8 +56,10 @@
 
     isSubmitting = true;
     mintError = '';
+    const expiry: PlatformKeyExpiry =
+      expiryMode === 'date' ? { mode: 'date', date: expiryDate } : { mode: expiryMode };
     try {
-      minted = await mintPlatformKey(toPlatformKeyRequest(name, email, expiryDate));
+      minted = await mintPlatformKey(toPlatformKeyRequest(name, email, expiry));
     } catch (error) {
       mintError = extractApiError(error);
     } finally {
@@ -123,10 +128,42 @@
           <span>Email:</span>
           <input type="email" bind:value={email} class="input" required maxlength="255" />
         </label>
-        <label class="label">
-          <span>Expiration date (optional, expires at 00:00 UTC):</span>
-          <input type="date" bind:value={expiryDate} class="input" min={minExpiryDate} />
-        </label>
+        <div class="grid gap-2" role="radiogroup" aria-label="Expiration">
+          <span class="font-semibold">Expiration:</span>
+          <label class="flex items-center gap-2">
+            <input type="radio" class="radio" bind:group={expiryMode} value="default" />
+            <span>Default (1 year)</span>
+          </label>
+          <label class="flex items-center gap-2">
+            <input type="radio" class="radio" bind:group={expiryMode} value="date" />
+            <span>Custom date</span>
+          </label>
+          {#if expiryMode === 'date'}
+            <label class="label ml-7">
+              <span>Expiration date (expires at 00:00 UTC):</span>
+              <input
+                type="date"
+                bind:value={expiryDate}
+                class="input"
+                min={minExpiryDate}
+                required
+              />
+            </label>
+          {/if}
+          <label class="flex items-center gap-2">
+            <input
+              type="radio"
+              class="radio"
+              bind:group={expiryMode}
+              value="never"
+              data-testid="expiry-never"
+            />
+            <span>
+              Never expires
+              <span class="text-warning-600 font-semibold">— not recommended</span>
+            </span>
+          </label>
+        </div>
       </fieldset>
       <footer class="flex justify-end space-x-2 mt-6">
         <button

--- a/src/lib/components/admin/api-key/cell/ApiKeyActions.svelte
+++ b/src/lib/components/admin/api-key/cell/ApiKeyActions.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import Modal from '$lib/components/Modal.svelte';
+  import { isTopAdmin } from '$lib/stores/User';
+  import { toaster } from '$lib/toaster';
+  import { revokeApiKey } from '$lib/stores/ApiKeys';
+  import { extractApiError } from '$lib/models/ApiKey';
+
+  const { data = { cell: '', row: { prefix: '', status: '' } } } = $props();
+
+  async function revoke() {
+    // defense-in-depth beyond the disabled trigger; matches the sibling admin action cells
+    if (!$isTopAdmin) return;
+    try {
+      await revokeApiKey(data.cell);
+      toaster.success({
+        title: `Successfully revoked API key '${data.row.prefix}'`,
+      });
+    } catch (error) {
+      toaster.error({
+        title: `Failed to revoke API key '${data.row.prefix}'`,
+        description: extractApiError(error),
+      });
+    }
+  }
+</script>
+
+{#if data.row.status === 'Active'}
+  <Modal
+    data-testid="api-key-{data.cell}-revoke"
+    title="Revoke API Key?"
+    confirmText="Revoke"
+    cancelText="Cancel"
+    confirmClass="preset-filled-error-500"
+    disabled={!$isTopAdmin}
+    onconfirm={revoke}
+    triggerBase="btn preset-tonal-error border border-error-500 hover:preset-filled-error-500"
+    withDefault
+  >
+    {#snippet trigger()}Revoke{/snippet}
+    <p>
+      Are you sure you want to revoke API key '{data.row.prefix}'? Revocation is permanent and
+      cannot be undone.
+    </p>
+  </Modal>
+{/if}

--- a/src/lib/components/admin/api-key/cell/ApiKeyActions.svelte
+++ b/src/lib/components/admin/api-key/cell/ApiKeyActions.svelte
@@ -8,7 +8,7 @@
   const { data = { cell: '', row: { prefix: '', status: '' } } } = $props();
 
   async function revoke() {
-    // defense-in-depth beyond the disabled trigger; matches the sibling admin action cells
+    // defense-in-depth beyond the disabled trigger
     if (!$isTopAdmin) return;
     try {
       await revokeApiKey(data.cell);

--- a/src/lib/components/admin/api-key/cell/ApiKeyStatus.svelte
+++ b/src/lib/components/admin/api-key/cell/ApiKeyStatus.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  let { data = { cell: '', row: {} } } = $props();
+
+  const presets: { [status: string]: string } = {
+    Active: 'preset-filled-success-500',
+    Revoked: 'preset-filled-error-500',
+    Expired: 'preset-filled-warning-500',
+  };
+</script>
+
+<span class="badge last:p-1 rounded-sm {presets[data.cell] || 'preset-tonal-surface'}"
+  >{data.cell}</span
+>

--- a/src/lib/components/admin/api-key/cell/ApiKeyType.svelte
+++ b/src/lib/components/admin/api-key/cell/ApiKeyType.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  let { data = { cell: '', row: {} } } = $props();
+</script>
+
+<span
+  class="badge last:p-1 rounded-sm {data.cell === 'PLATFORM'
+    ? 'preset-tonal-primary border border-primary-500'
+    : 'preset-tonal-surface border border-surface-500'}">{data.cell}</span
+>

--- a/src/lib/components/admin/api-key/cell/ApiKeyType.svelte
+++ b/src/lib/components/admin/api-key/cell/ApiKeyType.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  let { data = { cell: '', row: {} } } = $props();
-</script>
-
-<span
-  class="badge last:p-1 rounded-sm {data.cell === 'PLATFORM'
-    ? 'preset-tonal-primary border border-primary-500'
-    : 'preset-tonal-surface border border-surface-500'}">{data.cell}</span
->

--- a/src/lib/models/ApiKey.ts
+++ b/src/lib/models/ApiKey.ts
@@ -1,0 +1,80 @@
+export type ApiKeyType = 'USER' | 'PLATFORM';
+export type ApiKeyStatus = 'Active' | 'Revoked' | 'Expired';
+
+export interface ApiKeyMetadata {
+  uuid: string;
+  displayPrefix: string;
+  keyType: ApiKeyType;
+  name: string | null;
+  email: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  lastUsedAt: string | null;
+}
+
+export interface ApiKeyPage {
+  keys: ApiKeyMetadata[];
+  totalCount: number;
+  page: number;
+  size: number;
+}
+
+export interface PlatformKeyRequest {
+  name: string;
+  email: string;
+  expiresAt?: string;
+}
+
+export interface MintedPlatformKey {
+  apiKey: string;
+  uuid: string;
+  displayPrefix: string;
+  keyType: ApiKeyType;
+  expiresAt: string | null;
+}
+
+export function getApiKeyStatus(key: ApiKeyMetadata, now: Date = new Date()): ApiKeyStatus {
+  if (key.revokedAt) return 'Revoked';
+  if (key.expiresAt && new Date(key.expiresAt) < now) return 'Expired';
+  return 'Active';
+}
+
+export function formatInstant(instant: string | null | undefined, fallback = ''): string {
+  if (!instant) return fallback;
+  const dt = new Date(instant);
+  if (isNaN(dt.getTime())) return fallback;
+  // format in UTC: these are date-only displays of midnight-UTC instants (expiry, created),
+  // so local-timezone rendering would show the previous day west of UTC
+  const year = dt.toLocaleString('default', { year: 'numeric', timeZone: 'UTC' });
+  const month = dt.toLocaleString('default', { month: '2-digit', timeZone: 'UTC' });
+  const day = dt.toLocaleString('default', { day: '2-digit', timeZone: 'UTC' });
+  return `${year}-${month}-${day}`;
+}
+
+export function toPlatformKeyRequest(
+  name: string,
+  email: string,
+  expiryDate?: string,
+): PlatformKeyRequest {
+  const request: PlatformKeyRequest = { name: name.trim(), email: email.trim() };
+  if (expiryDate) {
+    request.expiresAt = `${expiryDate}T00:00:00Z`;
+  }
+  return request;
+}
+
+export function extractApiError(
+  error: unknown,
+  fallback = 'Something went wrong when sending your request.',
+): string {
+  const message = (error as { body?: { message?: string } })?.body?.message;
+  if (!message) return fallback;
+  try {
+    // PSAMA 400s arrive as a JSON body serialized into the error message
+    const parsed = JSON.parse(message);
+    return parsed?.message || fallback;
+  } catch {
+    return message;
+  }
+}

--- a/src/lib/models/ApiKey.ts
+++ b/src/lib/models/ApiKey.ts
@@ -24,7 +24,13 @@ export interface PlatformKeyRequest {
   name: string;
   email: string;
   expiresAt?: string;
+  neverExpires?: boolean;
 }
+
+export type PlatformKeyExpiry =
+  | { mode: 'default' }
+  | { mode: 'date'; date: string }
+  | { mode: 'never' };
 
 export interface MintedPlatformKey {
   apiKey: string;
@@ -55,11 +61,13 @@ export function formatInstant(instant: string | null | undefined, fallback = '')
 export function toPlatformKeyRequest(
   name: string,
   email: string,
-  expiryDate?: string,
+  expiry: PlatformKeyExpiry = { mode: 'default' },
 ): PlatformKeyRequest {
   const request: PlatformKeyRequest = { name: name.trim(), email: email.trim() };
-  if (expiryDate) {
-    request.expiresAt = `${expiryDate}T00:00:00Z`;
+  if (expiry.mode === 'date' && expiry.date) {
+    request.expiresAt = `${expiry.date}T00:00:00Z`;
+  } else if (expiry.mode === 'never') {
+    request.neverExpires = true;
   }
   return request;
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -46,6 +46,7 @@ export const Picsure = {
 
 export const Internal = {
   Log: `${API}/log`,
+  OpenProxy: `${API}/open`,
 };
 
 const USER = 'psama/user';

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -53,6 +53,11 @@ const USER = 'psama/user';
 
 export const Psama = {
   Application: 'psama/application',
+  ApiKey: {
+    Admin: 'psama/apiKey',
+    Platform: 'psama/apiKey/platform',
+    Open: 'psama/open/apiKey',
+  },
   Auth: 'psama/authentication',
   Open: {
     ApiKey: 'psama/open/apiKey',

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -57,5 +57,6 @@ export const routes: Route[] = [
     feature: 'manualRole',
   },
   { path: '/admin/users', text: 'Manage Users', privilege: [PicsurePrivileges.ADMIN] },
+  { path: '/admin/api-keys', text: 'API Keys', privilege: [PicsurePrivileges.ADMIN] },
   { path: '/help', text: 'Help' },
 ];

--- a/src/lib/stores/ApiKeys.ts
+++ b/src/lib/stores/ApiKeys.ts
@@ -1,0 +1,41 @@
+import { writable, type Writable } from 'svelte/store';
+
+import * as api from '$lib/api';
+import { Psama } from '$lib/paths';
+import type {
+  ApiKeyMetadata,
+  ApiKeyPage,
+  MintedPlatformKey,
+  PlatformKeyRequest,
+} from '$lib/models/ApiKey';
+
+// Bumped after every mutation so paginated views know to refetch their current page.
+export const listVersion: Writable<number> = writable(0);
+
+export function refreshApiKeys() {
+  listVersion.update((version) => version + 1);
+}
+
+export async function loadApiKeys(page = 0, size = 100): Promise<ApiKeyPage> {
+  return api.get(`${Psama.ApiKey.Admin}?page=${page}&size=${size}`);
+}
+
+export async function revokeApiKey(uuid: string): Promise<ApiKeyMetadata> {
+  const revoked: ApiKeyMetadata = await api.put(`${Psama.ApiKey.Admin}/${uuid}/revoke`, undefined);
+  refreshApiKeys();
+  return revoked;
+}
+
+export async function mintPlatformKey(request: PlatformKeyRequest): Promise<MintedPlatformKey> {
+  const minted: MintedPlatformKey = await api.post(Psama.ApiKey.Platform, request);
+  refreshApiKeys();
+  return minted;
+}
+
+export default {
+  listVersion,
+  refreshApiKeys,
+  loadApiKeys,
+  revokeApiKey,
+  mintPlatformKey,
+};

--- a/src/lib/stores/ApiKeys.ts
+++ b/src/lib/stores/ApiKeys.ts
@@ -16,8 +16,13 @@ export function refreshApiKeys() {
   listVersion.update((version) => version + 1);
 }
 
-export async function loadApiKeys(page = 0, size = 100): Promise<ApiKeyPage> {
-  return api.get(`${Psama.ApiKey.Admin}?page=${page}&size=${size}`);
+export async function loadApiKeys(
+  page = 0,
+  size = 100,
+  keyType?: 'USER' | 'PLATFORM',
+): Promise<ApiKeyPage> {
+  const typeParam = keyType ? `&keyType=${keyType}` : '';
+  return api.get(`${Psama.ApiKey.Admin}?page=${page}&size=${size}${typeParam}`);
 }
 
 export async function revokeApiKey(uuid: string): Promise<ApiKeyMetadata> {

--- a/src/routes/(picsure)/(authorized)/(admin)/admin/api-keys/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/(admin)/admin/api-keys/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { branding } from '$lib/configuration';
+  import Content from '$lib/components/Content.svelte';
+  import ErrorAlert from '$lib/components/ErrorAlert.svelte';
+  import ApiKeyTable from '$lib/components/admin/api-key/ApiKeyTable.svelte';
+  import MintPlatformKeyModal from '$lib/components/admin/api-key/MintPlatformKeyModal.svelte';
+  import { isTopAdmin } from '$lib/stores/User';
+</script>
+
+<svelte:head>
+  <title>{branding.applicationName} | API Keys</title>
+</svelte:head>
+<Content title="API Keys">
+  {#if !$isTopAdmin}
+    <ErrorAlert title="Top Administrator Only" color="warning">
+      <p>
+        API keys are READ ONLY for admin users. Please contact your administrator to make changes.
+      </p>
+    </ErrorAlert>
+  {/if}
+  <div class="flex gap-4 mb-6">
+    <div class="flex-auto">
+      <MintPlatformKeyModal />
+    </div>
+  </div>
+  <ApiKeyTable />
+</Content>

--- a/src/routes/(picsure)/(authorized)/(admin)/admin/api-keys/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/(admin)/admin/api-keys/+page.svelte
@@ -18,10 +18,16 @@
       </p>
     </ErrorAlert>
   {/if}
-  <div class="flex gap-4 mb-6">
-    <div class="flex-auto">
+  <section class="mb-10">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="h3">Platform Keys</h2>
       <MintPlatformKeyModal />
     </div>
-  </div>
-  <ApiKeyTable />
+    <ApiKeyTable keyType="PLATFORM" tableName="PlatformApiKeys" />
+  </section>
+
+  <section>
+    <h2 class="h3 mb-3">User Keys</h2>
+    <ApiKeyTable keyType="USER" tableName="UserApiKeys" />
+  </section>
 </Content>

--- a/src/routes/(picsure)/(authorized)/(admin)/admin/api-keys/+page.svelte
+++ b/src/routes/(picsure)/(authorized)/(admin)/admin/api-keys/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { branding } from '$lib/configuration';
+  import { config } from '$lib/configuration.svelte';
   import Content from '$lib/components/Content.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import ApiKeyTable from '$lib/components/admin/api-key/ApiKeyTable.svelte';
@@ -8,7 +8,7 @@
 </script>
 
 <svelte:head>
-  <title>{branding.applicationName} | API Keys</title>
+  <title>{config.branding.applicationName} | API Keys</title>
 </svelte:head>
 <Content title="API Keys">
   {#if !$isTopAdmin}

--- a/src/routes/api/v1/open/[...path]/+server.ts
+++ b/src/routes/api/v1/open/[...path]/+server.ts
@@ -1,0 +1,79 @@
+import { error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import type { RequestHandler } from './$types';
+
+/**
+ * Server-side proxy for anonymous (token-less) open-access data requests. api.ts routes them
+ * here so the deployment's PLATFORM API key can be attached without the key ever reaching the
+ * browser. Only the PIC-SURE data API is reachable through it — this must not become an open
+ * relay carrying the platform key to arbitrary upstream paths.
+ */
+const UPSTREAM_ORIGIN = 'http://localhost';
+
+const forward: RequestHandler = async ({ request, params, url }) => {
+  // Resolve the target first, then validate its NORMALIZED pathname: checking the raw param
+  // while fetching a string-concatenated URL is a parser differential — "picsure/../psama" (or
+  // its %2e%2e form, which SvelteKit decodes) passes a raw startsWith check but resolves to a
+  // non-picsure upstream, letting a caller reach other localhost services with the platform key.
+  const target = new URL(`${UPSTREAM_ORIGIN}/${params.path}`);
+  if (target.pathname !== '/picsure' && !target.pathname.startsWith('/picsure/')) {
+    error(404, 'Not found');
+  }
+  target.search = url.search;
+
+  if (!env.PICSURE_PLATFORM_API_KEY) {
+    console.error('[open-proxy] PICSURE_PLATFORM_API_KEY not set; forwarding without an API key');
+  }
+
+  const headers: Record<string, string> = {};
+  const contentType = request.headers.get('Content-Type');
+  if (contentType) {
+    headers['Content-Type'] = contentType;
+  }
+  const sessionId = request.headers.get('X-Session-Id');
+  if (sessionId) {
+    headers['X-Session-Id'] = sessionId;
+  }
+  const requestSource = request.headers.get('request-source');
+  if (requestSource) {
+    headers['request-source'] = requestSource;
+  }
+  if (env.PICSURE_PLATFORM_API_KEY) {
+    headers['X-PICSURE-API-Key'] = env.PICSURE_PLATFORM_API_KEY;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: request.method,
+      headers,
+      body: request.method === 'GET' ? undefined : await request.arrayBuffer(),
+      // never auto-follow: fetch re-sends X-PICSURE-API-Key on redirects, even cross-origin,
+      // which would hand the platform key to an arbitrary Location target
+      redirect: 'manual',
+    });
+  } catch (err) {
+    console.error('[open-proxy] Network error reaching upstream:', err);
+    error(502, 'Upstream unavailable');
+  }
+
+  // open-access data endpoints do not redirect; a 3xx here is unexpected and the key was not
+  // re-sent, so surface it as a gateway error rather than a broken Location-less response
+  if (upstream.status >= 300 && upstream.status < 400) {
+    console.error(`[open-proxy] Unexpected upstream redirect (${upstream.status}); not following`);
+    error(502, 'Upstream unavailable');
+  }
+
+  const responseHeaders = new Headers();
+  const upstreamContentType = upstream.headers.get('Content-Type');
+  if (upstreamContentType) {
+    responseHeaders.set('Content-Type', upstreamContentType);
+  }
+  return new Response(upstream.body, { status: upstream.status, headers: responseHeaders });
+};
+
+// mirror the methods api.ts routes through the proxy, so a token-less PUT/DELETE isn't a 405
+export const GET = forward;
+export const POST = forward;
+export const PUT = forward;
+export const DELETE = forward;

--- a/src/routes/api/v1/open/[...path]/+server.ts
+++ b/src/routes/api/v1/open/[...path]/+server.ts
@@ -8,17 +8,18 @@ import type { RequestHandler } from './$types';
  * browser. Only the PIC-SURE data API is reachable through it — this must not become an open
  * relay carrying the platform key to arbitrary upstream paths.
  */
-const UPSTREAM_ORIGIN = 'http://localhost';
-
 // warn once, not per request: with the key unset every anonymous request would repeat it
 let warnedMissingKey = false;
 
 const forward: RequestHandler = async ({ request, params, url, getClientAddress }) => {
+  // multi-host deployments don't serve the API from the frontend host over plain HTTP,
+  // so the internal origin must be wireable per deployment
+  const upstreamOrigin = env.PICSURE_INTERNAL_API_ORIGIN || 'http://localhost';
   // Resolve the target first, then validate its NORMALIZED pathname: checking the raw param
   // while fetching a string-concatenated URL is a parser differential — "picsure/../psama" (or
   // its %2e%2e form, which SvelteKit decodes) passes a raw startsWith check but resolves to a
-  // non-picsure upstream, letting a caller reach other localhost services with the platform key.
-  const target = new URL(`${UPSTREAM_ORIGIN}/${params.path}`);
+  // non-picsure upstream, letting a caller reach other internal services with the platform key.
+  const target = new URL(`${upstreamOrigin}/${params.path}`);
   if (target.pathname !== '/picsure' && !target.pathname.startsWith('/picsure/')) {
     error(404, 'Not found');
   }
@@ -30,11 +31,9 @@ const forward: RequestHandler = async ({ request, params, url, getClientAddress 
   }
 
   const headers: Record<string, string> = {};
-  // preserve the client's address across the hop: anonymous requests otherwise all reach the
-  // API as the frontend server, erasing per-client traceability in PSAMA's access logs
-  const forwardedFor = request.headers.get('X-Forwarded-For');
-  const clientAddress = getClientAddress();
-  headers['X-Forwarded-For'] = forwardedFor ? `${forwardedFor}, ${clientAddress}` : clientAddress;
+  // forward only the trusted client address: the incoming X-Forwarded-For header is
+  // caller-controlled, and preserving it would let requests falsify their audit attribution
+  headers['X-Forwarded-For'] = getClientAddress();
   headers['X-Forwarded-Host'] = url.host;
   const contentType = request.headers.get('Content-Type');
   if (contentType) {

--- a/src/routes/api/v1/open/[...path]/+server.ts
+++ b/src/routes/api/v1/open/[...path]/+server.ts
@@ -10,7 +10,10 @@ import type { RequestHandler } from './$types';
  */
 const UPSTREAM_ORIGIN = 'http://localhost';
 
-const forward: RequestHandler = async ({ request, params, url }) => {
+// warn once, not per request: with the key unset every anonymous request would repeat it
+let warnedMissingKey = false;
+
+const forward: RequestHandler = async ({ request, params, url, getClientAddress }) => {
   // Resolve the target first, then validate its NORMALIZED pathname: checking the raw param
   // while fetching a string-concatenated URL is a parser differential — "picsure/../psama" (or
   // its %2e%2e form, which SvelteKit decodes) passes a raw startsWith check but resolves to a
@@ -21,11 +24,18 @@ const forward: RequestHandler = async ({ request, params, url }) => {
   }
   target.search = url.search;
 
-  if (!env.PICSURE_PLATFORM_API_KEY) {
+  if (!env.PICSURE_PLATFORM_API_KEY && !warnedMissingKey) {
+    warnedMissingKey = true;
     console.error('[open-proxy] PICSURE_PLATFORM_API_KEY not set; forwarding without an API key');
   }
 
   const headers: Record<string, string> = {};
+  // preserve the client's address across the hop: anonymous requests otherwise all reach the
+  // API as the frontend server, erasing per-client traceability in PSAMA's access logs
+  const forwardedFor = request.headers.get('X-Forwarded-For');
+  const clientAddress = getClientAddress();
+  headers['X-Forwarded-For'] = forwardedFor ? `${forwardedFor}, ${clientAddress}` : clientAddress;
+  headers['X-Forwarded-Host'] = url.host;
   const contentType = request.headers.get('Content-Type');
   if (contentType) {
     headers['Content-Type'] = contentType;

--- a/src/routes/api/v1/open/[...path]/+server.ts
+++ b/src/routes/api/v1/open/[...path]/+server.ts
@@ -39,6 +39,10 @@ const forward: RequestHandler = async ({ request, params, url, getClientAddress 
   if (contentType) {
     headers['Content-Type'] = contentType;
   }
+  const accept = request.headers.get('Accept');
+  if (accept) {
+    headers['Accept'] = accept;
+  }
   const sessionId = request.headers.get('X-Session-Id');
   if (sessionId) {
     headers['X-Session-Id'] = sessionId;
@@ -81,8 +85,6 @@ const forward: RequestHandler = async ({ request, params, url, getClientAddress 
   return new Response(upstream.body, { status: upstream.status, headers: responseHeaders });
 };
 
-// mirror the methods api.ts routes through the proxy, so a token-less PUT/DELETE isn't a 405
+// only the methods token-less UI traffic actually uses; widening this widens the credentialed surface
 export const GET = forward;
 export const POST = forward;
-export const PUT = forward;
-export const DELETE = forward;

--- a/src/routes/api/v1/open/server.test.ts
+++ b/src/routes/api/v1/open/server.test.ts
@@ -61,17 +61,34 @@ describe('+server /api/v1/open/[...path]', () => {
     await expect(response.text()).resolves.toBe('{"ok":true}');
   });
 
-  it('forwards the client address and appends to an existing X-Forwarded-For chain', async () => {
+  it('forwards only the trusted client address, discarding a spoofed X-Forwarded-For', async () => {
     const bare = makeEvent('GET', 'picsure/query/sync');
     await GET(bare);
     expect(fetchMock.mock.calls[0][1].headers['X-Forwarded-For']).toBe('203.0.113.9');
     expect(fetchMock.mock.calls[0][1].headers['X-Forwarded-Host']).toBe('localhost');
 
-    const chained = makeEvent('GET', 'picsure/query/sync', {
-      headers: { 'X-Forwarded-For': '198.51.100.7' },
+    const spoofed = makeEvent('GET', 'picsure/query/sync', {
+      headers: { 'X-Forwarded-For': '1.2.3.4' },
     });
-    await GET(chained);
-    expect(fetchMock.mock.calls[1][1].headers['X-Forwarded-For']).toBe('198.51.100.7, 203.0.113.9');
+    await GET(spoofed);
+    expect(fetchMock.mock.calls[1][1].headers['X-Forwarded-For']).toBe('203.0.113.9');
+  });
+
+  it('reaches the API through the configured internal origin', async () => {
+    mockEnv.PICSURE_INTERNAL_API_ORIGIN = 'http://api-host:8080';
+    const event = makeEvent('GET', 'picsure/query/sync');
+
+    await GET(event);
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe('http://api-host:8080/picsure/query/sync');
+  });
+
+  it('still rejects traversal outside picsure under a custom internal origin', async () => {
+    mockEnv.PICSURE_INTERNAL_API_ORIGIN = 'http://api-host:8080';
+    const event = makeEvent('GET', 'picsure/../psama/user/me');
+
+    await expect(GET(event)).rejects.toMatchObject({ status: 404 });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('forwards POST bodies and content type', async () => {

--- a/src/routes/api/v1/open/server.test.ts
+++ b/src/routes/api/v1/open/server.test.ts
@@ -106,6 +106,17 @@ describe('+server /api/v1/open/[...path]', () => {
     expect(new TextDecoder().decode(init.body)).toBe('{"query":{}}');
   });
 
+  it('forwards the Accept header for content negotiation', async () => {
+    const event = makeEvent('GET', 'picsure/query/sync', {
+      headers: { Accept: 'application/json' },
+    });
+
+    await GET(event);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers['Accept']).toBe('application/json');
+  });
+
   it('never forwards Authorization or Cookie headers upstream', async () => {
     const event = makeEvent('GET', 'picsure/query/sync', {
       headers: { Authorization: 'Bearer stale.jwt', Cookie: 'session=abc' },

--- a/src/routes/api/v1/open/server.test.ts
+++ b/src/routes/api/v1/open/server.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockEnv: Record<string, string | undefined> = {};
+
+vi.mock('$env/dynamic/private', () => ({
+  env: new Proxy(
+    {},
+    {
+      get: (_, key: string) => mockEnv[key],
+    },
+  ),
+}));
+
+// Must import after mocks are set up
+const { GET, POST } = await import('./[...path]/+server');
+
+function makeEvent(
+  method: string,
+  path: string,
+  options: { search?: string; body?: string; headers?: Record<string, string> } = {},
+) {
+  const url = new URL(`http://localhost/api/v1/open/${path}${options.search || ''}`);
+  const request = new Request(url, {
+    method,
+    headers: options.headers,
+    body: options.body,
+  });
+  return { request, params: { path }, url } as unknown as Parameters<typeof POST>[0];
+}
+
+function upstreamResponse(body = '{"ok":true}', status = 200) {
+  return new Response(body, { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('+server /api/v1/open/[...path]', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockEnv = { PICSURE_PLATFORM_API_KEY: 'picsure_platformKey123' };
+    fetchMock = vi.fn().mockResolvedValue(upstreamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('attaches the platform key and forwards to the upstream data API with the query string', async () => {
+    const event = makeEvent('GET', 'picsure/proxy/dictionary-api/facets', { search: '?q=age' });
+
+    const response = await GET(event);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [target, init] = fetchMock.mock.calls[0];
+    expect(String(target)).toBe('http://localhost/picsure/proxy/dictionary-api/facets?q=age');
+    expect(init.headers['X-PICSURE-API-Key']).toBe('picsure_platformKey123');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    await expect(response.text()).resolves.toBe('{"ok":true}');
+  });
+
+  it('forwards POST bodies and content type', async () => {
+    const event = makeEvent('POST', 'picsure/query/sync', {
+      body: '{"query":{}}',
+      headers: { 'Content-Type': 'application/json', 'X-Session-Id': 'session-1' },
+    });
+
+    await POST(event);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toContain('application/json');
+    expect(init.headers['X-Session-Id']).toBe('session-1');
+    expect(new TextDecoder().decode(init.body)).toBe('{"query":{}}');
+  });
+
+  it('never forwards Authorization or Cookie headers upstream', async () => {
+    const event = makeEvent('GET', 'picsure/query/sync', {
+      headers: { Authorization: 'Bearer stale.jwt', Cookie: 'session=abc' },
+    });
+
+    await GET(event);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers['Authorization']).toBeUndefined();
+    expect(init.headers['Cookie']).toBeUndefined();
+  });
+
+  it('rejects non picsure paths without contacting the upstream', async () => {
+    const event = makeEvent('GET', 'psama/user/me');
+
+    await expect(GET(event)).rejects.toMatchObject({ status: 404 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects path traversal that normalizes outside picsure', async () => {
+    // decoded ".." segments would normalize to a non-picsure upstream if only the raw string were checked
+    for (const path of ['picsure/../psama/user/me', 'picsure/../../psama/admin']) {
+      const event = makeEvent('GET', path);
+      await expect(GET(event)).rejects.toMatchObject({ status: 404 });
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards without a key and logs an error when the platform key is unset', async () => {
+    mockEnv = {};
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const event = makeEvent('GET', 'picsure/query/sync');
+
+    await GET(event);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers['X-PICSURE-API-Key']).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('passes upstream error statuses through', async () => {
+    fetchMock.mockResolvedValue(upstreamResponse('denied', 401));
+    const event = makeEvent('GET', 'picsure/query/sync');
+
+    const response = await GET(event);
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe('denied');
+  });
+
+  it('returns 502 when the upstream is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const event = makeEvent('GET', 'picsure/query/sync');
+
+    await expect(GET(event)).rejects.toMatchObject({ status: 502 });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/routes/api/v1/open/server.test.ts
+++ b/src/routes/api/v1/open/server.test.ts
@@ -25,7 +25,12 @@ function makeEvent(
     headers: options.headers,
     body: options.body,
   });
-  return { request, params: { path }, url } as unknown as Parameters<typeof POST>[0];
+  return {
+    request,
+    params: { path },
+    url,
+    getClientAddress: () => '203.0.113.9',
+  } as unknown as Parameters<typeof POST>[0];
 }
 
 function upstreamResponse(body = '{"ok":true}', status = 200) {
@@ -54,6 +59,19 @@ describe('+server /api/v1/open/[...path]', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('application/json');
     await expect(response.text()).resolves.toBe('{"ok":true}');
+  });
+
+  it('forwards the client address and appends to an existing X-Forwarded-For chain', async () => {
+    const bare = makeEvent('GET', 'picsure/query/sync');
+    await GET(bare);
+    expect(fetchMock.mock.calls[0][1].headers['X-Forwarded-For']).toBe('203.0.113.9');
+    expect(fetchMock.mock.calls[0][1].headers['X-Forwarded-Host']).toBe('localhost');
+
+    const chained = makeEvent('GET', 'picsure/query/sync', {
+      headers: { 'X-Forwarded-For': '198.51.100.7' },
+    });
+    await GET(chained);
+    expect(fetchMock.mock.calls[1][1].headers['X-Forwarded-For']).toBe('198.51.100.7, 203.0.113.9');
   });
 
   it('forwards POST bodies and content type', async () => {

--- a/tests/component/ApiKeyTable.test.ts
+++ b/tests/component/ApiKeyTable.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within, waitFor } from '@testing-library/svelte';
+
+vi.mock('$lib/logger', () => ({
+  log: vi.fn(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createLog: vi.fn((...args: any[]) => args),
+  getPageContext: vi.fn(() => 'test-context'),
+}));
+
+// The real ExpandableRow store eagerly imports explorer components that touch
+// localStorage at module load. Row.svelte only needs the store contract.
+vi.mock('$lib/stores/ExpandableRow', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    activeTable: writable(''),
+    activeRow: writable(''),
+    activeComponent: writable(undefined),
+    setActiveRow: vi.fn(),
+  };
+});
+
+vi.mock('$lib/stores/User', async () => {
+  const { writable } = await import('svelte/store');
+  return { isTopAdmin: writable(true) };
+});
+
+vi.mock('$lib/toaster', () => ({
+  toaster: { success: vi.fn(), error: vi.fn() },
+}));
+
+const storeMocks = vi.hoisted(() => ({
+  loadApiKeys: vi.fn(),
+  revokeApiKey: vi.fn(),
+}));
+
+vi.mock('$lib/stores/ApiKeys', async () => {
+  const { writable } = await import('svelte/store');
+  const listVersion = writable(0);
+  return {
+    listVersion,
+    refreshApiKeys: () => listVersion.update((version) => version + 1),
+    loadApiKeys: storeMocks.loadApiKeys,
+    revokeApiKey: storeMocks.revokeApiKey,
+    mintPlatformKey: vi.fn(),
+  };
+});
+
+import ApiKeyTable from '$lib/components/admin/api-key/ApiKeyTable.svelte';
+import { refreshApiKeys } from '$lib/stores/ApiKeys';
+import type { ApiKeyMetadata } from '$lib/models/ApiKey';
+
+const activeKey: ApiKeyMetadata = {
+  uuid: 'uuid-active',
+  displayPrefix: 'abc12345',
+  keyType: 'USER',
+  name: 'Alice',
+  email: 'alice@example.org',
+  createdAt: '2026-01-01T00:00:00Z',
+  expiresAt: '2099-01-01T00:00:00Z',
+  revokedAt: null,
+  lastUsedAt: '2026-06-01T00:00:00Z',
+};
+
+const revokedKey: ApiKeyMetadata = {
+  uuid: 'uuid-revoked',
+  displayPrefix: 'def67890',
+  keyType: 'PLATFORM',
+  name: 'Pipeline',
+  email: 'ops@example.org',
+  createdAt: '2026-02-01T00:00:00Z',
+  expiresAt: null,
+  revokedAt: '2026-03-01T00:00:00Z',
+  lastUsedAt: null,
+};
+
+const expiredKey: ApiKeyMetadata = {
+  uuid: 'uuid-expired',
+  displayPrefix: 'ghi13579',
+  keyType: 'USER',
+  name: null,
+  email: null,
+  createdAt: '2025-01-01T00:00:00Z',
+  expiresAt: '2025-06-01T00:00:00Z',
+  revokedAt: null,
+  lastUsedAt: null,
+};
+
+function mockPage(keys: ApiKeyMetadata[]) {
+  storeMocks.loadApiKeys.mockResolvedValue({
+    keys,
+    totalCount: keys.length,
+    page: 0,
+    size: 10,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ApiKeyTable', () => {
+  it('renders keys with masked prefix, type, and derived status', async () => {
+    mockPage([activeKey, revokedKey, expiredKey]);
+    render(ApiKeyTable);
+
+    expect(await screen.findByText('picsure_abc12345…')).toBeInTheDocument();
+    expect(screen.getByText('picsure_def67890…')).toBeInTheDocument();
+    expect(screen.getByText('picsure_ghi13579…')).toBeInTheDocument();
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Revoked')).toBeInTheDocument();
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+
+    expect(screen.getByText('PLATFORM')).toBeInTheDocument();
+    expect(screen.getAllByText('USER')).toHaveLength(2);
+    expect(screen.getByText('alice@example.org')).toBeInTheDocument();
+    expect(screen.getAllByText('Never').length).toBeGreaterThan(0);
+  });
+
+  it('requests the first server page using the table page size', async () => {
+    mockPage([activeKey]);
+    render(ApiKeyTable);
+
+    await screen.findByText('picsure_abc12345…');
+    expect(storeMocks.loadApiKeys).toHaveBeenCalledWith(0, expect.any(Number));
+  });
+
+  it('only offers revoke on active keys', async () => {
+    mockPage([activeKey, revokedKey, expiredKey]);
+    render(ApiKeyTable);
+
+    await screen.findByText('picsure_abc12345…');
+    expect(screen.getByTestId('api-key-uuid-active-revoke-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('api-key-uuid-revoked-revoke-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('api-key-uuid-expired-revoke-btn')).not.toBeInTheDocument();
+  });
+
+  it('revokes a key through the confirmation dialog and refreshes the list', async () => {
+    mockPage([activeKey]);
+    storeMocks.revokeApiKey.mockImplementation(async () => {
+      storeMocks.loadApiKeys.mockResolvedValue({
+        keys: [{ ...activeKey, revokedAt: '2026-07-14T00:00:00Z' }],
+        totalCount: 1,
+        page: 0,
+        size: 10,
+      });
+      refreshApiKeys();
+      return { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' };
+    });
+    render(ApiKeyTable);
+
+    await fireEvent.click(await screen.findByTestId('api-key-uuid-active-revoke-btn'));
+
+    const dialog = await screen.findByTestId('api-key-uuid-active-revoke');
+    expect(dialog).toHaveTextContent('permanent and cannot be undone');
+
+    await fireEvent.click(within(dialog).getByRole('button', { name: 'Revoke' }));
+
+    expect(storeMocks.revokeApiKey).toHaveBeenCalledWith('uuid-active');
+    expect(await screen.findByText('Revoked')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByTestId('api-key-uuid-active-revoke-btn')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows an inline alert when loading the list fails', async () => {
+    storeMocks.loadApiKeys.mockRejectedValue({
+      status: 400,
+      body: { message: JSON.stringify({ errorType: 'error', message: 'list failed' }) },
+    });
+    render(ApiKeyTable);
+
+    const alert = await screen.findByTestId('api-key-list-error');
+    expect(alert).toHaveTextContent('list failed');
+  });
+});

--- a/tests/component/ApiKeyTable.test.ts
+++ b/tests/component/ApiKeyTable.test.ts
@@ -102,9 +102,9 @@ beforeEach(() => {
 });
 
 describe('ApiKeyTable', () => {
-  it('renders keys with masked prefix, type, and derived status', async () => {
+  it('renders keys with masked prefix and derived status', async () => {
     mockPage([activeKey, revokedKey, expiredKey]);
-    render(ApiKeyTable);
+    render(ApiKeyTable, { props: { keyType: 'USER', tableName: 'UserApiKeys' } });
 
     expect(await screen.findByText('picsure_abc12345…')).toBeInTheDocument();
     expect(screen.getByText('picsure_def67890…')).toBeInTheDocument();
@@ -114,23 +114,21 @@ describe('ApiKeyTable', () => {
     expect(screen.getByText('Revoked')).toBeInTheDocument();
     expect(screen.getByText('Expired')).toBeInTheDocument();
 
-    expect(screen.getByText('PLATFORM')).toBeInTheDocument();
-    expect(screen.getAllByText('USER')).toHaveLength(2);
     expect(screen.getByText('alice@example.org')).toBeInTheDocument();
     expect(screen.getAllByText('Never').length).toBeGreaterThan(0);
   });
 
-  it('requests the first server page using the table page size', async () => {
+  it('requests the first server page filtered by its key type', async () => {
     mockPage([activeKey]);
-    render(ApiKeyTable);
+    render(ApiKeyTable, { props: { keyType: 'PLATFORM', tableName: 'PlatformApiKeys' } });
 
     await screen.findByText('picsure_abc12345…');
-    expect(storeMocks.loadApiKeys).toHaveBeenCalledWith(0, expect.any(Number));
+    expect(storeMocks.loadApiKeys).toHaveBeenCalledWith(0, expect.any(Number), 'PLATFORM');
   });
 
   it('only offers revoke on active keys', async () => {
     mockPage([activeKey, revokedKey, expiredKey]);
-    render(ApiKeyTable);
+    render(ApiKeyTable, { props: { keyType: 'USER', tableName: 'UserApiKeys' } });
 
     await screen.findByText('picsure_abc12345…');
     expect(screen.getByTestId('api-key-uuid-active-revoke-btn')).toBeInTheDocument();
@@ -150,7 +148,7 @@ describe('ApiKeyTable', () => {
       refreshApiKeys();
       return { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' };
     });
-    render(ApiKeyTable);
+    render(ApiKeyTable, { props: { keyType: 'USER', tableName: 'UserApiKeys' } });
 
     await fireEvent.click(await screen.findByTestId('api-key-uuid-active-revoke-btn'));
 
@@ -171,7 +169,7 @@ describe('ApiKeyTable', () => {
       status: 400,
       body: { message: JSON.stringify({ errorType: 'error', message: 'list failed' }) },
     });
-    render(ApiKeyTable);
+    render(ApiKeyTable, { props: { keyType: 'USER', tableName: 'UserApiKeys' } });
 
     const alert = await screen.findByTestId('api-key-list-error');
     expect(alert).toHaveTextContent('list failed');

--- a/tests/component/MintPlatformKeyModal.test.ts
+++ b/tests/component/MintPlatformKeyModal.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 
 vi.mock('$lib/logger', () => ({
   log: vi.fn(),
@@ -96,20 +96,15 @@ describe('MintPlatformKeyModal', () => {
     });
   });
 
-  it('cannot be dismissed accidentally — only via the explicit acknowledge button', async () => {
+  it('closes the reveal and clears the key from view when done', async () => {
     storeMocks.mintPlatformKey.mockResolvedValue(mintedFixture);
     render(MintPlatformKeyModal);
 
     await openFormAndFill();
     await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+    await screen.findByTestId('minted-api-key');
 
-    const reveal = await screen.findByTestId('mint-key-reveal');
-    expect(within(reveal).queryByTestId('modal-close-button')).not.toBeInTheDocument();
-
-    await fireEvent.keyDown(document.body, { key: 'Escape' });
-    expect(screen.getByTestId('minted-api-key')).toBeInTheDocument();
-
-    await fireEvent.click(screen.getByTestId('acknowledge-minted-key'));
+    await fireEvent.click(screen.getByTestId('done-minted-key'));
     await waitFor(() => expect(screen.queryByTestId('minted-api-key')).not.toBeInTheDocument());
   });
 
@@ -120,7 +115,7 @@ describe('MintPlatformKeyModal', () => {
     await openFormAndFill();
     await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
     await screen.findByTestId('minted-api-key');
-    await fireEvent.click(screen.getByTestId('acknowledge-minted-key'));
+    await fireEvent.click(screen.getByTestId('done-minted-key'));
 
     const logged = JSON.stringify([vi.mocked(log).mock.calls, vi.mocked(createLog).mock.calls]);
     expect(logged).not.toContain(FAKE_KEY);

--- a/tests/component/MintPlatformKeyModal.test.ts
+++ b/tests/component/MintPlatformKeyModal.test.ts
@@ -84,7 +84,8 @@ describe('MintPlatformKeyModal', () => {
     render(MintPlatformKeyModal);
 
     await openFormAndFill();
-    await fireEvent.input(screen.getByLabelText(/expiration date/i), {
+    await fireEvent.click(screen.getByLabelText(/custom date/i));
+    await fireEvent.input(await screen.findByLabelText(/expiration date/i), {
       target: { value: '2099-01-01' },
     });
     await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
@@ -93,6 +94,21 @@ describe('MintPlatformKeyModal', () => {
       name: 'CI Pipeline',
       email: 'ops@example.org',
       expiresAt: '2099-01-01T00:00:00Z',
+    });
+  });
+
+  it('sends neverExpires only when the never option is deliberately selected', async () => {
+    storeMocks.mintPlatformKey.mockResolvedValue(mintedFixture);
+    render(MintPlatformKeyModal);
+
+    await openFormAndFill();
+    await fireEvent.click(screen.getByTestId('expiry-never'));
+    await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+
+    expect(storeMocks.mintPlatformKey).toHaveBeenCalledWith({
+      name: 'CI Pipeline',
+      email: 'ops@example.org',
+      neverExpires: true,
     });
   });
 

--- a/tests/component/MintPlatformKeyModal.test.ts
+++ b/tests/component/MintPlatformKeyModal.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+
+vi.mock('$lib/logger', () => ({
+  log: vi.fn(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createLog: vi.fn((...args: any[]) => args),
+  getPageContext: vi.fn(() => 'test-context'),
+}));
+
+vi.mock('$lib/stores/User', async () => {
+  const { writable } = await import('svelte/store');
+  return { isTopAdmin: writable(true) };
+});
+
+const storeMocks = vi.hoisted(() => ({
+  mintPlatformKey: vi.fn(),
+}));
+
+vi.mock('$lib/stores/ApiKeys', async () => {
+  const { writable } = await import('svelte/store');
+  const listVersion = writable(0);
+  return {
+    listVersion,
+    refreshApiKeys: () => listVersion.update((version) => version + 1),
+    loadApiKeys: vi.fn(),
+    revokeApiKey: vi.fn(),
+    mintPlatformKey: storeMocks.mintPlatformKey,
+  };
+});
+
+import MintPlatformKeyModal from '$lib/components/admin/api-key/MintPlatformKeyModal.svelte';
+import { log, createLog } from '$lib/logger';
+
+const FAKE_KEY = 'picsure_FAKE-TEST-FIXTURE-VALUE-0000000000000000000';
+
+const mintedFixture = {
+  apiKey: FAKE_KEY,
+  uuid: 'uuid-new',
+  displayPrefix: 'zzz99999',
+  keyType: 'PLATFORM' as const,
+  expiresAt: null,
+};
+
+async function openFormAndFill() {
+  await fireEvent.click(screen.getByTestId('mint-platform-key-btn'));
+  await fireEvent.input(await screen.findByLabelText(/name/i), {
+    target: { value: 'CI Pipeline' },
+  });
+  await fireEvent.input(screen.getByLabelText(/email/i), {
+    target: { value: 'ops@example.org' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MintPlatformKeyModal', () => {
+  it('mints a key and reveals it once with a see-once warning', async () => {
+    storeMocks.mintPlatformKey.mockResolvedValue(mintedFixture);
+    render(MintPlatformKeyModal);
+
+    await openFormAndFill();
+    await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+
+    expect(storeMocks.mintPlatformKey).toHaveBeenCalledWith({
+      name: 'CI Pipeline',
+      email: 'ops@example.org',
+    });
+
+    const key = await screen.findByTestId('minted-api-key');
+    expect(key).toHaveTextContent(FAKE_KEY);
+
+    const warning = screen.getByRole('alert');
+    expect(warning).toHaveTextContent(/shown only once/i);
+    expect(warning).toHaveTextContent(/cannot be recovered/i);
+  });
+
+  it('sends the expiry date as a UTC start-of-day instant', async () => {
+    storeMocks.mintPlatformKey.mockResolvedValue(mintedFixture);
+    render(MintPlatformKeyModal);
+
+    await openFormAndFill();
+    await fireEvent.input(screen.getByLabelText(/expiration date/i), {
+      target: { value: '2099-01-01' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+
+    expect(storeMocks.mintPlatformKey).toHaveBeenCalledWith({
+      name: 'CI Pipeline',
+      email: 'ops@example.org',
+      expiresAt: '2099-01-01T00:00:00Z',
+    });
+  });
+
+  it('cannot be dismissed accidentally — only via the explicit acknowledge button', async () => {
+    storeMocks.mintPlatformKey.mockResolvedValue(mintedFixture);
+    render(MintPlatformKeyModal);
+
+    await openFormAndFill();
+    await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+
+    const reveal = await screen.findByTestId('mint-key-reveal');
+    expect(within(reveal).queryByTestId('modal-close-button')).not.toBeInTheDocument();
+
+    await fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(screen.getByTestId('minted-api-key')).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByTestId('acknowledge-minted-key'));
+    await waitFor(() => expect(screen.queryByTestId('minted-api-key')).not.toBeInTheDocument());
+  });
+
+  it('never passes the plaintext key to the logger', async () => {
+    storeMocks.mintPlatformKey.mockResolvedValue(mintedFixture);
+    render(MintPlatformKeyModal);
+
+    await openFormAndFill();
+    await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+    await screen.findByTestId('minted-api-key');
+    await fireEvent.click(screen.getByTestId('acknowledge-minted-key'));
+
+    const logged = JSON.stringify([vi.mocked(log).mock.calls, vi.mocked(createLog).mock.calls]);
+    expect(logged).not.toContain(FAKE_KEY);
+    expect(logged).not.toContain(mintedFixture.displayPrefix);
+  });
+
+  it('shows the backend message inline when minting fails', async () => {
+    storeMocks.mintPlatformKey.mockRejectedValue({
+      status: 400,
+      body: {
+        message: JSON.stringify({ errorType: 'error', message: 'Expiry must be in the future' }),
+      },
+    });
+    render(MintPlatformKeyModal);
+
+    await openFormAndFill();
+    await fireEvent.click(screen.getByRole('button', { name: 'Mint Key' }));
+
+    const alert = await screen.findByTestId('mint-key-error');
+    expect(alert).toHaveTextContent('Expiry must be in the future');
+    expect(screen.queryByTestId('minted-api-key')).not.toBeInTheDocument();
+  });
+});

--- a/tests/component/setup.ts
+++ b/tests/component/setup.ts
@@ -41,3 +41,23 @@ if (typeof globalThis.localStorage === 'undefined') {
     writable: true,
   });
 }
+
+// happy-dom does not implement the Web Animations API, which zag-js (via
+// @skeletonlabs/skeleton-svelte dialogs) calls when opening/closing modals.
+// Provide a no-op stub so modal-based components can be exercised in tests.
+if (typeof Element !== 'undefined' && !Element.prototype.animate) {
+  Element.prototype.animate = function () {
+    return {
+      finished: Promise.resolve(),
+      cancel: () => {},
+      finish: () => {},
+      play: () => {},
+      pause: () => {},
+      reverse: () => {},
+      onfinish: null,
+      oncancel: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as unknown as Animation;
+  };
+}

--- a/tests/end-to-end/admin/api-keys/test.ts
+++ b/tests/end-to-end/admin/api-keys/test.ts
@@ -263,6 +263,7 @@ test.describe('mint platform key flow', () => {
     await page.getByTestId('mint-platform-key-btn').click();
     await page.getByLabel(/name/i).fill('CI Pipeline');
     await page.getByLabel(/email/i).fill('ops@example.org');
+    await page.getByLabel(/custom date/i).check();
     await page.getByLabel(/expiration date/i).fill('2099-01-01');
     const postRequest = page.waitForRequest(
       (request) => request.method() === 'POST' && request.url().includes('/psama/apiKey/platform'),

--- a/tests/end-to-end/admin/api-keys/test.ts
+++ b/tests/end-to-end/admin/api-keys/test.ts
@@ -1,5 +1,5 @@
-import { expect, type Route } from '@playwright/test';
-import { test, mockApiSuccess, mockApiSuccessByMethod } from '../../custom-context';
+import { expect, type BrowserContext, type Route } from '@playwright/test';
+import { test, mockApiSuccessByMethod } from '../../custom-context';
 import { userIsLoggedIn } from '../../utils';
 import type { ApiKeyMetadata } from '../../../../src/lib/models/ApiKey';
 
@@ -58,37 +58,56 @@ const mintedResponse = {
 
 test.use({ storageState: 'tests/end-to-end/.auth/superUser.json' });
 
+// The page renders one table per key type, each querying ?keyType=…; route by that param so a
+// key never appears in both tables (which would duplicate its testid).
+async function routeByKeyType(
+  context: BrowserContext,
+  platform: ApiKeyMetadata[],
+  user: ApiKeyMetadata[],
+) {
+  await context.route('**/psama/apiKey?*', (route: Route) => {
+    const keyType = new URL(route.request().url()).searchParams.get('keyType');
+    return route.fulfill({ json: keyPage(keyType === 'PLATFORM' ? platform : user) });
+  });
+}
+
 test.beforeEach(async ({ context }) => {
-  await mockApiSuccess(context, '*/**/psama/apiKey*', keyPage([activeKey, revokedKey, expiredKey]));
+  await routeByKeyType(context, [revokedKey], [activeKey, expiredKey]);
 });
 
 test.describe('api keys list', () => {
-  test('Displays keys with masked prefix, type, and derived status', async ({ page }) => {
+  test('Splits keys into platform and user tables with derived status', async ({ page }) => {
     // Given
     await page.goto('/admin/api-keys');
     await userIsLoggedIn(page);
 
     // Then
-    const table = page.getByTestId('ApiKeys-table');
-    await expect(table).toContainText('picsure_abc12345…');
-    await expect(table).toContainText('picsure_def67890…');
-    await expect(table).toContainText('picsure_ghi13579…');
-    await expect(table).toContainText('PLATFORM');
-    await expect(table).toContainText('Active');
-    await expect(table).toContainText('Revoked');
-    await expect(table).toContainText('Expired');
+    const platformTable = page.getByTestId('PlatformApiKeys-table');
+    await expect(platformTable).toContainText('picsure_def67890…');
+    await expect(platformTable).toContainText('Revoked');
+    await expect(platformTable).not.toContainText('picsure_abc12345…');
+
+    const userTable = page.getByTestId('UserApiKeys-table');
+    await expect(userTable).toContainText('picsure_abc12345…');
+    await expect(userTable).toContainText('picsure_ghi13579…');
+    await expect(userTable).toContainText('Active');
+    await expect(userTable).toContainText('Expired');
+    await expect(userTable).not.toContainText('picsure_def67890…');
   });
 
-  test('Shows the server total in the table footer', async ({ page }) => {
+  test('Shows the server total in the table footer', async ({ context, page }) => {
     // Given
-    await page.route('*/**/psama/apiKey*', (route: Route) =>
+    await routeByKeyType(context, [], [{ ...activeKey }]);
+    await context.route('**/psama/apiKey?*keyType=USER*', (route: Route) =>
       route.fulfill({ json: { ...keyPage([activeKey]), totalCount: 42 } }),
     );
     await page.goto('/admin/api-keys');
     await userIsLoggedIn(page);
 
     // Then
-    await expect(page.locator('.table-wrap footer')).toContainText('42');
+    await expect(
+      page.getByTestId('UserApiKeys-table').locator('..').locator('footer'),
+    ).toContainText('42');
   });
 
   test('Only active keys have a revoke button', async ({ page }) => {
@@ -107,12 +126,15 @@ test.describe('revoke flow', () => {
   test('Revoking requires confirmation and refreshes the list', async ({ page }) => {
     // Given
     let revoked = false;
-    await page.route('*/**/psama/apiKey*', (route: Route) =>
-      route.fulfill({
-        json: keyPage([revoked ? { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' } : activeKey]),
-      }),
-    );
-    await page.route('*/**/psama/apiKey/*/revoke', (route: Route) => {
+    await page.route('**/psama/apiKey?*', (route: Route) => {
+      const keyType = new URL(route.request().url()).searchParams.get('keyType');
+      const userKeys =
+        keyType === 'USER'
+          ? [revoked ? { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' } : activeKey]
+          : [];
+      return route.fulfill({ json: keyPage(userKeys) });
+    });
+    await page.route('**/psama/apiKey/*/revoke', (route: Route) => {
       revoked = true;
       return route.fulfill({ json: { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' } });
     });
@@ -131,7 +153,7 @@ test.describe('revoke flow', () => {
 
     // Then
     await putRequest;
-    await expect(page.getByTestId('ApiKeys-table')).toContainText('Revoked');
+    await expect(page.getByTestId('UserApiKeys-table')).toContainText('Revoked');
     await expect(page.getByTestId('api-key-uuid-active-revoke-btn')).toHaveCount(0);
   });
 
@@ -175,16 +197,60 @@ test.describe('mint platform key flow', () => {
     await expect(reveal.getByTestId('minted-api-key')).toHaveText(FAKE_KEY);
     // the modal portals its content, so locate the warning by test id rather than a scoped role
     await expect(page.getByTestId('minted-key-warning')).toContainText(/shown only once/i);
-    // No accidental dismissal: no close button, and Escape does not close it
-    await expect(reveal.getByTestId('modal-close-button')).toHaveCount(0);
-    await page.keyboard.press('Escape');
-    await expect(reveal.getByTestId('minted-api-key')).toBeVisible();
 
     // When
-    await reveal.getByTestId('acknowledge-minted-key').click();
+    await reveal.getByTestId('done-minted-key').click();
 
     // Then
     await expect(page.getByTestId('minted-api-key')).toHaveCount(0);
+  });
+
+  test('The revealed key cannot be dismissed accidentally, only via Done', async ({ page }) => {
+    // Given
+    await mockApiSuccessByMethod(page, '*/**/psama/apiKey/platform', 'POST', mintedResponse);
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('mint-platform-key-btn').click();
+    await page.getByLabel(/name/i).fill('CI Pipeline');
+    await page.getByLabel(/email/i).fill('ops@example.org');
+    await page.getByRole('button', { name: 'Mint Key' }).click();
+    await expect(page.getByTestId('minted-api-key')).toBeVisible();
+
+    // Then: no × close button, and Escape does not discard the only copy of the key
+    await expect(page.getByTestId('modal-close-button')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('minted-api-key')).toBeVisible();
+
+    // Only Done closes it
+    await page.getByTestId('done-minted-key').click();
+    await expect(page.getByTestId('minted-api-key')).toHaveCount(0);
+  });
+
+  test('Cannot close the modal while the mint request is in flight', async ({ page }) => {
+    // Given a slow mint response
+    await page.route('**/psama/apiKey/platform', async (route: Route) => {
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      return route.fulfill({ json: mintedResponse });
+    });
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When minting is in progress
+    await page.getByTestId('mint-platform-key-btn').click();
+    await page.getByLabel(/name/i).fill('CI Pipeline');
+    await page.getByLabel(/email/i).fill('ops@example.org');
+    await page.getByRole('button', { name: 'Mint Key' }).click();
+
+    // Then Cancel is disabled and Escape does not close the modal (which would orphan the key)
+    await expect(page.getByRole('button', { name: 'Minting…' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('mint-platform-key')).toBeVisible();
+
+    // And once it resolves the key is revealed, not lost
+    await expect(page.getByTestId('minted-api-key')).toHaveText(FAKE_KEY);
   });
 
   test('Sends the expiry date as a UTC instant', async ({ page }) => {

--- a/tests/end-to-end/admin/api-keys/test.ts
+++ b/tests/end-to-end/admin/api-keys/test.ts
@@ -1,0 +1,268 @@
+import { expect, type Route } from '@playwright/test';
+import { test, mockApiSuccess, mockApiSuccessByMethod } from '../../custom-context';
+import { userIsLoggedIn } from '../../utils';
+import type { ApiKeyMetadata } from '../../../../src/lib/models/ApiKey';
+
+const FAKE_KEY = 'picsure_FAKE-TEST-FIXTURE-VALUE-0000000000000000000';
+
+const activeKey: ApiKeyMetadata = {
+  uuid: 'uuid-active',
+  displayPrefix: 'abc12345',
+  keyType: 'USER',
+  name: 'Alice',
+  email: 'alice@example.org',
+  createdAt: '2026-01-01T00:00:00Z',
+  expiresAt: '2099-01-01T00:00:00Z',
+  revokedAt: null,
+  lastUsedAt: '2026-06-01T00:00:00Z',
+};
+
+const revokedKey: ApiKeyMetadata = {
+  uuid: 'uuid-revoked',
+  displayPrefix: 'def67890',
+  keyType: 'PLATFORM',
+  name: 'Pipeline',
+  email: 'ops@example.org',
+  createdAt: '2026-02-01T00:00:00Z',
+  expiresAt: null,
+  revokedAt: '2026-03-01T00:00:00Z',
+  lastUsedAt: null,
+};
+
+const expiredKey: ApiKeyMetadata = {
+  uuid: 'uuid-expired',
+  displayPrefix: 'ghi13579',
+  keyType: 'USER',
+  name: null,
+  email: null,
+  createdAt: '2025-01-01T00:00:00Z',
+  expiresAt: '2025-06-01T00:00:00Z',
+  revokedAt: null,
+  lastUsedAt: null,
+};
+
+const keyPage = (keys: ApiKeyMetadata[]) => ({
+  keys,
+  totalCount: keys.length,
+  page: 0,
+  size: 10,
+});
+
+const mintedResponse = {
+  apiKey: FAKE_KEY,
+  uuid: 'uuid-new',
+  displayPrefix: 'zzz99999',
+  keyType: 'PLATFORM',
+  expiresAt: null,
+};
+
+test.use({ storageState: 'tests/end-to-end/.auth/superUser.json' });
+
+test.beforeEach(async ({ context }) => {
+  await mockApiSuccess(context, '*/**/psama/apiKey*', keyPage([activeKey, revokedKey, expiredKey]));
+});
+
+test.describe('api keys list', () => {
+  test('Displays keys with masked prefix, type, and derived status', async ({ page }) => {
+    // Given
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // Then
+    const table = page.getByTestId('ApiKeys-table');
+    await expect(table).toContainText('picsure_abc12345…');
+    await expect(table).toContainText('picsure_def67890…');
+    await expect(table).toContainText('picsure_ghi13579…');
+    await expect(table).toContainText('PLATFORM');
+    await expect(table).toContainText('Active');
+    await expect(table).toContainText('Revoked');
+    await expect(table).toContainText('Expired');
+  });
+
+  test('Shows the server total in the table footer', async ({ page }) => {
+    // Given
+    await page.route('*/**/psama/apiKey*', (route: Route) =>
+      route.fulfill({ json: { ...keyPage([activeKey]), totalCount: 42 } }),
+    );
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // Then
+    await expect(page.locator('.table-wrap footer')).toContainText('42');
+  });
+
+  test('Only active keys have a revoke button', async ({ page }) => {
+    // Given
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // Then
+    await expect(page.getByTestId('api-key-uuid-active-revoke-btn')).toBeVisible();
+    await expect(page.getByTestId('api-key-uuid-revoked-revoke-btn')).toHaveCount(0);
+    await expect(page.getByTestId('api-key-uuid-expired-revoke-btn')).toHaveCount(0);
+  });
+});
+
+test.describe('revoke flow', () => {
+  test('Revoking requires confirmation and refreshes the list', async ({ page }) => {
+    // Given
+    let revoked = false;
+    await page.route('*/**/psama/apiKey*', (route: Route) =>
+      route.fulfill({
+        json: keyPage([revoked ? { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' } : activeKey]),
+      }),
+    );
+    await page.route('*/**/psama/apiKey/*/revoke', (route: Route) => {
+      revoked = true;
+      return route.fulfill({ json: { ...activeKey, revokedAt: '2026-07-14T00:00:00Z' } });
+    });
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('api-key-uuid-active-revoke-btn').click();
+    const dialog = page.getByTestId('api-key-uuid-active-revoke');
+    await expect(dialog).toContainText('permanent and cannot be undone');
+    const putRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'PUT' && request.url().includes('/psama/apiKey/uuid-active/revoke'),
+    );
+    await dialog.getByRole('button', { name: 'Revoke' }).click();
+
+    // Then
+    await putRequest;
+    await expect(page.getByTestId('ApiKeys-table')).toContainText('Revoked');
+    await expect(page.getByTestId('api-key-uuid-active-revoke-btn')).toHaveCount(0);
+  });
+
+  test('Cancelling the confirmation does not revoke', async ({ page }) => {
+    // Given
+    let putCalled = false;
+    await page.route('*/**/psama/apiKey/*/revoke', (route: Route) => {
+      putCalled = true;
+      return route.fulfill({ json: activeKey });
+    });
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('api-key-uuid-active-revoke-btn').click();
+    const dialog = page.getByTestId('api-key-uuid-active-revoke');
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+    // Then
+    await expect(dialog).not.toBeVisible();
+    expect(putCalled).toBe(false);
+  });
+});
+
+test.describe('mint platform key flow', () => {
+  test('Minting reveals the key exactly once with a see-once warning', async ({ page }) => {
+    // Given
+    await mockApiSuccessByMethod(page, '*/**/psama/apiKey/platform', 'POST', mintedResponse);
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('mint-platform-key-btn').click();
+    await page.getByLabel(/name/i).fill('CI Pipeline');
+    await page.getByLabel(/email/i).fill('ops@example.org');
+    await page.getByRole('button', { name: 'Mint Key' }).click();
+
+    // Then
+    const reveal = page.getByTestId('mint-key-reveal');
+    await expect(reveal).toBeVisible();
+    await expect(reveal.getByTestId('minted-api-key')).toHaveText(FAKE_KEY);
+    // the modal portals its content, so locate the warning by test id rather than a scoped role
+    await expect(page.getByTestId('minted-key-warning')).toContainText(/shown only once/i);
+    // No accidental dismissal: no close button, and Escape does not close it
+    await expect(reveal.getByTestId('modal-close-button')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+    await expect(reveal.getByTestId('minted-api-key')).toBeVisible();
+
+    // When
+    await reveal.getByTestId('acknowledge-minted-key').click();
+
+    // Then
+    await expect(page.getByTestId('minted-api-key')).toHaveCount(0);
+  });
+
+  test('Sends the expiry date as a UTC instant', async ({ page }) => {
+    // Given
+    await mockApiSuccessByMethod(page, '*/**/psama/apiKey/platform', 'POST', mintedResponse);
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('mint-platform-key-btn').click();
+    await page.getByLabel(/name/i).fill('CI Pipeline');
+    await page.getByLabel(/email/i).fill('ops@example.org');
+    await page.getByLabel(/expiration date/i).fill('2099-01-01');
+    const postRequest = page.waitForRequest(
+      (request) => request.method() === 'POST' && request.url().includes('/psama/apiKey/platform'),
+    );
+    await page.getByRole('button', { name: 'Mint Key' }).click();
+
+    // Then
+    const request = await postRequest;
+    expect(request.postDataJSON()).toEqual({
+      name: 'CI Pipeline',
+      email: 'ops@example.org',
+      expiresAt: '2099-01-01T00:00:00Z',
+    });
+  });
+
+  test('Shows the backend message inline when minting fails', async ({ page }) => {
+    // Given
+    await page.route('*/**/psama/apiKey/platform', (route: Route) =>
+      route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ errorType: 'error', message: 'Expiry must be in the future' }),
+      }),
+    );
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('mint-platform-key-btn').click();
+    await page.getByLabel(/name/i).fill('CI Pipeline');
+    await page.getByLabel(/email/i).fill('ops@example.org');
+    await page.getByRole('button', { name: 'Mint Key' }).click();
+
+    // Then
+    await expect(page.getByTestId('mint-key-error')).toContainText('Expiry must be in the future');
+    await expect(page.getByTestId('mint-key-reveal')).toHaveCount(0);
+  });
+
+  test('Enforces required name and email', async ({ page }) => {
+    // Given
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // When
+    await page.getByTestId('mint-platform-key-btn').click();
+    await page.getByRole('button', { name: 'Mint Key' }).click();
+
+    // Then
+    const invalid = await page
+      .getByLabel(/name/i)
+      .evaluate((element: HTMLInputElement) => element.validationMessage);
+    expect(invalid).toMatch(/([Pp]lease )?[Ff]ill out this field.?/);
+  });
+});
+
+test.describe('Admin on API Keys page', () => {
+  test.use({ storageState: 'tests/end-to-end/.auth/adminUser.json' });
+
+  test('Mint and revoke are disabled when not top admin', async ({ page }) => {
+    // Given
+    await page.goto('/admin/api-keys');
+    await userIsLoggedIn(page);
+
+    // Then
+    await expect(page.getByTestId('error-alert')).toBeVisible();
+    await expect(page.getByTestId('mint-platform-key-btn')).toBeDisabled();
+    await expect(page.getByTestId('api-key-uuid-active-revoke-btn')).toBeDisabled();
+  });
+});

--- a/tests/unit/ApiKey.test.ts
+++ b/tests/unit/ApiKey.test.ts
@@ -86,15 +86,23 @@ describe('toPlatformKeyRequest', () => {
     });
   });
 
-  it('omits expiresAt when no expiry date is given', () => {
-    const request = toPlatformKeyRequest('Pipeline', 'ops@example.org', '');
+  it('omits expiresAt and neverExpires for the default expiry', () => {
+    const request = toPlatformKeyRequest('Pipeline', 'ops@example.org', { mode: 'default' });
     expect('expiresAt' in request).toBe(false);
+    expect('neverExpires' in request).toBe(false);
   });
 
   it('converts a date input value to a UTC start-of-day instant', () => {
-    expect(toPlatformKeyRequest('Pipeline', 'ops@example.org', '2027-01-01').expiresAt).toBe(
-      '2027-01-01T00:00:00Z',
-    );
+    expect(
+      toPlatformKeyRequest('Pipeline', 'ops@example.org', { mode: 'date', date: '2027-01-01' })
+        .expiresAt,
+    ).toBe('2027-01-01T00:00:00Z');
+  });
+
+  it('sets neverExpires without an expiresAt for a never expiry', () => {
+    const request = toPlatformKeyRequest('Pipeline', 'ops@example.org', { mode: 'never' });
+    expect(request.neverExpires).toBe(true);
+    expect('expiresAt' in request).toBe(false);
   });
 });
 

--- a/tests/unit/ApiKey.test.ts
+++ b/tests/unit/ApiKey.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  getApiKeyStatus,
+  formatInstant,
+  toPlatformKeyRequest,
+  extractApiError,
+  type ApiKeyMetadata,
+} from '$lib/models/ApiKey';
+
+const baseKey: ApiKeyMetadata = {
+  uuid: 'uuid-1',
+  displayPrefix: 'abc12345',
+  keyType: 'USER',
+  name: null,
+  email: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  expiresAt: null,
+  revokedAt: null,
+  lastUsedAt: null,
+};
+
+const now = new Date('2026-07-14T12:00:00Z');
+
+describe('getApiKeyStatus', () => {
+  it('returns Active for a key with no revocation and no expiry', () => {
+    expect(getApiKeyStatus(baseKey, now)).toBe('Active');
+  });
+
+  it('returns Active for a key expiring in the future', () => {
+    const key = { ...baseKey, expiresAt: '2027-01-01T00:00:00Z' };
+    expect(getApiKeyStatus(key, now)).toBe('Active');
+  });
+
+  it('returns Expired when expiresAt is in the past', () => {
+    const key = { ...baseKey, expiresAt: '2026-01-02T00:00:00Z' };
+    expect(getApiKeyStatus(key, now)).toBe('Expired');
+  });
+
+  it('returns Revoked when revokedAt is set', () => {
+    const key = { ...baseKey, revokedAt: '2026-06-01T00:00:00Z' };
+    expect(getApiKeyStatus(key, now)).toBe('Revoked');
+  });
+
+  it('prefers Revoked over Expired when both apply', () => {
+    const key = {
+      ...baseKey,
+      revokedAt: '2026-06-01T00:00:00Z',
+      expiresAt: '2026-01-02T00:00:00Z',
+    };
+    expect(getApiKeyStatus(key, now)).toBe('Revoked');
+  });
+});
+
+describe('formatInstant', () => {
+  it('formats an ISO instant as a YYYY-MM-DD date', () => {
+    expect(formatInstant('2026-03-05T12:30:00Z')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('renders a midnight-UTC instant as that UTC calendar day regardless of local timezone', () => {
+    // west of UTC this rolls back to 2025-12-31 unless formatted in UTC
+    const original = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    try {
+      expect(formatInstant('2026-01-01T00:00:00Z')).toBe('2026-01-01');
+    } finally {
+      process.env.TZ = original;
+    }
+  });
+
+  it('returns the fallback for null and undefined', () => {
+    expect(formatInstant(null, 'Never')).toBe('Never');
+    expect(formatInstant(undefined, 'Never')).toBe('Never');
+  });
+
+  it('returns the fallback for an unparseable instant', () => {
+    expect(formatInstant('not-a-date', '—')).toBe('—');
+  });
+});
+
+describe('toPlatformKeyRequest', () => {
+  it('trims name and email', () => {
+    expect(toPlatformKeyRequest(' Pipeline ', ' ops@example.org ')).toEqual({
+      name: 'Pipeline',
+      email: 'ops@example.org',
+    });
+  });
+
+  it('omits expiresAt when no expiry date is given', () => {
+    const request = toPlatformKeyRequest('Pipeline', 'ops@example.org', '');
+    expect('expiresAt' in request).toBe(false);
+  });
+
+  it('converts a date input value to a UTC start-of-day instant', () => {
+    expect(toPlatformKeyRequest('Pipeline', 'ops@example.org', '2027-01-01').expiresAt).toBe(
+      '2027-01-01T00:00:00Z',
+    );
+  });
+});
+
+describe('extractApiError', () => {
+  it('unwraps a JSON error body from an HttpError message', () => {
+    const error = {
+      status: 400,
+      body: { message: JSON.stringify({ errorType: 'error', message: 'Expiry must be future' }) },
+    };
+    expect(extractApiError(error)).toBe('Expiry must be future');
+  });
+
+  it('returns a plain-text error message as-is', () => {
+    const error = { status: 400, body: { message: 'plain failure' } };
+    expect(extractApiError(error)).toBe('plain failure');
+  });
+
+  it('falls back for errors without a message', () => {
+    expect(extractApiError(new TypeError('boom'), 'fallback')).toBe('fallback');
+    expect(extractApiError(undefined, 'fallback')).toBe('fallback');
+  });
+});

--- a/tests/unit/ApiKeys.test.ts
+++ b/tests/unit/ApiKeys.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { get as getStore } from 'svelte/store';
+
+vi.mock('$lib/api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+}));
+
+import * as api from '$lib/api';
+import {
+  loadApiKeys,
+  revokeApiKey,
+  mintPlatformKey,
+  listVersion,
+  refreshApiKeys,
+} from '$lib/stores/ApiKeys';
+
+const mockGet = vi.mocked(api.get);
+const mockPost = vi.mocked(api.post);
+const mockPut = vi.mocked(api.put);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ApiKeys store', () => {
+  it('loads a page of keys from the admin endpoint', async () => {
+    const page = { keys: [], totalCount: 0, page: 2, size: 50 };
+    mockGet.mockResolvedValue(page);
+
+    const result = await loadApiKeys(2, 50);
+
+    expect(mockGet).toHaveBeenCalledWith('psama/apiKey?page=2&size=50');
+    expect(result).toEqual(page);
+  });
+
+  it('defaults to page 0 with size 100', async () => {
+    mockGet.mockResolvedValue({ keys: [], totalCount: 0, page: 0, size: 100 });
+
+    await loadApiKeys();
+
+    expect(mockGet).toHaveBeenCalledWith('psama/apiKey?page=0&size=100');
+  });
+
+  it('revokes a key via PUT and bumps the list version', async () => {
+    const revoked = { uuid: 'uuid-1', revokedAt: '2026-07-14T00:00:00Z' };
+    mockPut.mockResolvedValue(revoked);
+    const before = getStore(listVersion);
+
+    const result = await revokeApiKey('uuid-1');
+
+    expect(mockPut).toHaveBeenCalledWith('psama/apiKey/uuid-1/revoke', undefined);
+    expect(result).toEqual(revoked);
+    expect(getStore(listVersion)).toBe(before + 1);
+  });
+
+  it('mints a platform key via POST and bumps the list version', async () => {
+    const minted = {
+      apiKey: 'picsure_FAKE-TEST-FIXTURE-VALUE-0000000000000000000',
+      uuid: 'uuid-2',
+      displayPrefix: 'abc12345',
+      keyType: 'PLATFORM',
+      expiresAt: null,
+    };
+    mockPost.mockResolvedValue(minted);
+    const request = { name: 'Pipeline', email: 'ops@example.org' };
+    const before = getStore(listVersion);
+
+    const result = await mintPlatformKey(request);
+
+    expect(mockPost).toHaveBeenCalledWith('psama/apiKey/platform', request);
+    expect(result).toEqual(minted);
+    expect(getStore(listVersion)).toBe(before + 1);
+  });
+
+  it('does not bump the list version when the mutation fails', async () => {
+    mockPut.mockRejectedValue({ status: 400, body: { message: 'unknown uuid' } });
+    const before = getStore(listVersion);
+
+    await expect(revokeApiKey('bad-uuid')).rejects.toBeTruthy();
+
+    expect(getStore(listVersion)).toBe(before);
+  });
+
+  it('refreshApiKeys increments the list version', () => {
+    const before = getStore(listVersion);
+    refreshApiKeys();
+    expect(getStore(listVersion)).toBe(before + 1);
+  });
+});

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -98,7 +98,7 @@ describe('api', () => {
     it('get() sends a GET request', async () => {
       await get('picsure/query');
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://example.com/picsure/query',
+        'https://example.com/api/v1/open/picsure/query',
         expect.objectContaining({ method: 'GET' }),
       );
     });
@@ -106,7 +106,7 @@ describe('api', () => {
     it('post() sends a POST request', async () => {
       await post('picsure/query', { foo: 'bar' });
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://example.com/picsure/query',
+        'https://example.com/api/v1/open/picsure/query',
         expect.objectContaining({ method: 'POST' }),
       );
     });
@@ -114,7 +114,7 @@ describe('api', () => {
     it('put() sends a PUT request', async () => {
       await put('picsure/query', { foo: 'bar' });
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://example.com/picsure/query',
+        'https://example.com/api/v1/open/picsure/query',
         expect.objectContaining({ method: 'PUT' }),
       );
     });
@@ -122,7 +122,7 @@ describe('api', () => {
     it('del() sends a DELETE request', async () => {
       await del('picsure/query');
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://example.com/picsure/query',
+        'https://example.com/api/v1/open/picsure/query',
         expect.objectContaining({ method: 'DELETE' }),
       );
     });
@@ -377,7 +377,57 @@ describe('api', () => {
       await get('picsure/query/sync');
 
       expect(fetchMock).toHaveBeenCalledWith(
+        'https://example.com/api/v1/open/picsure/query/sync',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('open-access proxy routing', () => {
+    it('routes token-less picsure requests through the open proxy', async () => {
+      await get('picsure/query/sync');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://example.com/api/v1/open/picsure/query/sync',
+        expect.any(Object),
+      );
+    });
+
+    it('sends picsure requests directly when a token exists', async () => {
+      (localStorage.getItem as Mock).mockReturnValue('my-token');
+      await get('picsure/query/sync');
+
+      expect(fetchMock).toHaveBeenCalledWith(
         'https://example.com/picsure/query/sync',
+        expect.any(Object),
+      );
+    });
+
+    it('proxies token-less picsure requests even when authenticate:false suppresses the token', async () => {
+      // a logged-in user querying the open-access variant still needs the platform key
+      (localStorage.getItem as Mock).mockReturnValue('my-token');
+      await post('picsure/query/sync', {}, undefined, false);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://example.com/api/v1/open/picsure/query/sync',
+        expect.any(Object),
+      );
+    });
+
+    it('does not attach a token to authenticate:false requests', async () => {
+      (localStorage.getItem as Mock).mockReturnValue('my-token');
+      await post('picsure/query/sync', {}, undefined, false);
+
+      const headers = fetchMock.mock.calls[0][1].headers;
+      expect(headers['Authorization']).toBeUndefined();
+      expect(headers['request-source']).toBe('Open');
+    });
+
+    it('never proxies non-picsure paths', async () => {
+      await get('psama/open/validate');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://example.com/psama/open/validate',
         expect.any(Object),
       );
     });


### PR DESCRIPTION
## What

- **Server-side proxy** `/api/v1/open/[...path]`: `api.ts` routes all token-less `picsure/` requests through it, and it attaches the deployment's PLATFORM key (`PICSURE_PLATFORM_API_KEY`, server-only env) so the key never reaches the browser. Validates the normalized upstream pathname (traversal-safe), never follows redirects (no key leakage to arbitrary `Location` targets), strips `Authorization`/`Cookie`, and forwards `X-Forwarded-For`/`X-Forwarded-Host` so per-client traceability survives the hop.
- **Admin page** `/admin/api-keys`: separate Platform and User key tables (server-paged via the new `keyType` filter), revoke with confirmation, and a mint-platform-key modal with explicit expiry modes — Default (backend TTL), Custom date, or an explicit Never-expires opt-in. The minted key is revealed once with copy support and cleared on any close path.

Pairs with hms-dbmi/pic-sure-auth-microapp#298 and hms-dbmi/pic-sure#275; safe to merge in any order since backend enforcement defaults off and the proxy simply forwards without a key until the env var is set.

## Deferred

Deployment wiring for `PICSURE_PLATFORM_API_KEY` (until set, the proxy forwards keyless and logs one error).
