### PR TITLE
[ALS-7762] Warn users before navigating to external sites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,7 @@ VITE_API_CONFIG_BRANDING=ui:branding
 #VITE_ANALYZE_API=true
 
 #VITE_ENABLE_TOS=false
+#VITE_CONFIRM_EXTERNAL_NAVIGATION=false #Show a confirmation modal before following links to external sites
 #VITE_ALLOW_EXPORT=true #Page
 #VITE_ALLOW_EXPORT_ENABLED=true #Search Result Icon
 #VITE_DASHBOARD_DRAWER=false

--- a/.env.test
+++ b/.env.test
@@ -95,6 +95,7 @@ VITE_API_CONFIG_BRANDING=ui:branding
 #VITE_ENFORCE_TOS_ACCEPT=true
 #VITE_OR_QUERIES=true
 #VITE_RESTORE_V2_QUERY=true
+#VITE_CONFIRM_EXTERNAL_NAVIGATION=true
 
 # Variant Explorer Settings - kept commented out, same reasoning as the Features block above.
 # Tests that need these mock them via '/api/config' directly (e.g. setup.ts mocks

--- a/src/lib/assets/configuration.json
+++ b/src/lib/assets/configuration.json
@@ -251,5 +251,12 @@
   },
   "termsOfService": {
     "rejectionUrl": "https://avillach-lab.hms.harvard.edu/pic-sure"
+  },
+  "externalLinkWarning": {
+    "title": "",
+    "message": "",
+    "newTabMessage": "",
+    "okText": "OK",
+    "cancelText": "Cancel"
   }
 }

--- a/src/lib/components/ExternalLinkWarning.svelte
+++ b/src/lib/components/ExternalLinkWarning.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import Modal from '$lib/components/Modal.svelte';
+  import { config } from '$lib/configuration.svelte';
+  import { log, createLog } from '$lib/logger';
+
+  let open = $state(false);
+  let pendingUrl: string | null = $state(null);
+  let openInNewTab = $state(false);
+
+  const cfg = $derived(config.branding.externalLinkWarning);
+  const title = $derived(cfg.title || `Leaving ${config.branding.applicationName}`);
+  const message = $derived(
+    cfg.message || `Are you sure you want to leave ${config.branding.applicationName}?`,
+  );
+  const newTabMessage = $derived(
+    cfg.newTabMessage || 'This external website will be opened as a new tab in your browser.',
+  );
+
+  function intercept(event: MouseEvent) {
+    if (event.type === 'auxclick' && event.button !== 1) return;
+    const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null;
+    if (!(anchor instanceof HTMLAnchorElement) || anchor.hasAttribute('download')) return;
+    let url: URL;
+    try {
+      url = new URL(anchor.href);
+    } catch {
+      return;
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
+    if (url.host === window.location.host) return;
+    // Capture-phase preventDefault stops navigation, but the anchor's own click
+    // handlers still run — a cancelled navigation still emits link_click logs.
+    event.preventDefault();
+    openInNewTab =
+      anchor.target === '_blank' ||
+      event.type === 'auxclick' ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey;
+    pendingUrl = url.href;
+    open = true;
+    log(
+      createLog('NAVIGATION', 'external_link.warning_shown', {
+        url: pendingUrl,
+        newTab: openInNewTab,
+      }),
+    );
+  }
+
+  function proceed() {
+    if (!pendingUrl) return;
+    log(
+      createLog('NAVIGATION', 'external_link.confirmed', {
+        url: pendingUrl,
+        newTab: openInNewTab,
+      }),
+    );
+    if (openInNewTab) {
+      window.open(pendingUrl, '_blank', 'noopener,noreferrer');
+    } else {
+      window.location.assign(pendingUrl);
+    }
+    pendingUrl = null;
+  }
+
+  // Cancellation is detected from the open state rather than Modal's onclose:
+  // Escape and outside-click dismissals bypass onclose entirely. proceed() clears
+  // pendingUrl synchronously before effects flush, so confirms never log a cancel.
+  $effect(() => {
+    if (!open && pendingUrl) {
+      log(createLog('NAVIGATION', 'external_link.cancelled', { url: pendingUrl }));
+      pendingUrl = null;
+    }
+  });
+</script>
+
+<svelte:window onclickcapture={intercept} onauxclickcapture={intercept} />
+
+<Modal
+  bind:open
+  withDefault
+  {title}
+  cancelText={cfg.cancelText || 'Cancel'}
+  confirmText={cfg.okText || 'OK'}
+  onconfirm={proceed}
+  data-testid="external-link-warning"
+>
+  <p>
+    {message}{#if openInNewTab}&nbsp;{newTabMessage}{/if}
+  </p>
+</Modal>

--- a/src/lib/models/Configuration.ts
+++ b/src/lib/models/Configuration.ts
@@ -12,6 +12,7 @@ export type Features = Indexable & {
   analyzeApi: boolean;
   collaborate: boolean;
   confirmDownload: boolean;
+  confirmExternalNavigation: boolean;
   dashboard: boolean;
   dashboardDrawer: boolean;
   dataRequests: boolean;
@@ -201,6 +202,13 @@ export type Branding = Indexable & {
   termsOfService: {
     rejectionUrl: string;
   };
+  externalLinkWarning: {
+    title: string;
+    message: string;
+    newTabMessage: string;
+    okText: string;
+    cancelText: string;
+  };
 };
 
 export type ConfigObject = {
@@ -316,6 +324,7 @@ export function mapFeatures(apiFeatures: ConfigObject[]): Features {
     analyzeApi: parse('ANALYZE_API', true),
     collaborate: parse('COLLABORATE', false),
     confirmDownload: parse('CONFIRM_DOWNLOAD', false),
+    confirmExternalNavigation: parse('CONFIRM_EXTERNAL_NAVIGATION', false),
     dataRequests: parse('DATA_REQUESTS', false),
     discover: parse('DISCOVER', false),
     dashboard: parse('DASHBOARD', false),
@@ -491,6 +500,13 @@ export function mapBranding(hostname: string, apiBranding: ConfigObject[] = []):
       statFields: {},
       termsOfService: {
         rejectionUrl: '',
+      },
+      externalLinkWarning: {
+        title: '',
+        message: '',
+        newTabMessage: '',
+        okText: 'OK',
+        cancelText: 'Cancel',
       },
     },
     configJson,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,8 +3,10 @@
   import { afterNavigate } from '$app/navigation';
   import '@fortawesome/fontawesome-free/css/all.min.css';
   import '../styles/app.css';
+  import { config } from '$lib/configuration.svelte';
   import { initSanitizeConfig } from '$lib/utilities/HTML';
   import GoogleTracking from '$lib/components/tracking/GoogleTracking.svelte';
+  import ExternalLinkWarning from '$lib/components/ExternalLinkWarning.svelte';
   import { log, createLog } from '$lib/logger';
 
   let { children }: { children?: Snippet } = $props();
@@ -25,4 +27,7 @@
 <main class="w-full h-full">
   {@render children?.()}
   <GoogleTracking />
+  {#if config.features.confirmExternalNavigation}
+    <ExternalLinkWarning />
+  {/if}
 </main>

--- a/tests/component/ExternalLinkWarning.test.ts
+++ b/tests/component/ExternalLinkWarning.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+vi.mock('$lib/configuration.svelte', () => ({
+  config: {
+    branding: {
+      applicationName: 'PIC-SURE-TEST',
+      externalLinkWarning: {},
+    },
+  },
+}));
+
+vi.mock('$lib/logger', () => ({
+  log: vi.fn(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createLog: vi.fn((eventType: any, action: any, metadata: any) => ({
+    event_type: eventType,
+    action,
+    metadata,
+  })),
+}));
+
+import ExternalLinkWarning from '$lib/components/ExternalLinkWarning.svelte';
+import { config } from '$lib/configuration.svelte';
+import { log } from '$lib/logger';
+
+const emptyWarningConfig = () => ({
+  title: '',
+  message: '',
+  newTabMessage: '',
+  okText: '',
+  cancelText: '',
+});
+
+const EXTERNAL_URL = 'https://example.org/page';
+
+function insertAnchor(attributes: Record<string, string>): HTMLAnchorElement {
+  const anchor = document.createElement('a');
+  Object.entries(attributes).forEach(([name, value]) => anchor.setAttribute(name, value));
+  anchor.textContent = 'test link';
+  document.body.appendChild(anchor);
+  return anchor;
+}
+
+let openSpy: ReturnType<typeof vi.spyOn>;
+let assignSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  config.branding.externalLinkWarning = emptyWarningConfig();
+  vi.mocked(log).mockClear();
+  openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+  assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.querySelectorAll('a').forEach((anchor) => anchor.remove());
+});
+
+describe('ExternalLinkWarning', () => {
+  it('opens the modal with default title and prevents navigation on external link click', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL });
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    await fireEvent(anchor, event);
+
+    expect(screen.getByTestId('external-link-warning')).toBeInTheDocument();
+    expect(screen.getByText('Leaving PIC-SURE-TEST')).toBeInTheDocument();
+    expect(screen.getByText(/Are you sure you want to leave PIC-SURE-TEST\?/)).toBeInTheDocument();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('cancel closes the modal without navigating', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL });
+
+    await fireEvent.click(anchor);
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByText('Leaving PIC-SURE-TEST')).not.toBeInTheDocument();
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it('OK opens a new tab for target="_blank" links and mentions the new tab', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL, target: '_blank' });
+
+    await fireEvent.click(anchor);
+    expect(
+      screen.getByText(/This external website will be opened as a new tab in your browser\./),
+    ).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    expect(openSpy).toHaveBeenCalledWith(EXTERNAL_URL, '_blank', 'noopener,noreferrer');
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it('OK navigates in the same tab for plain links, without the new tab message', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL });
+
+    await fireEvent.click(anchor);
+    expect(
+      screen.queryByText(/This external website will be opened as a new tab in your browser\./),
+    ).not.toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    expect(assignSpy).toHaveBeenCalledWith(EXTERNAL_URL);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats modifier clicks as new tab navigation', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL });
+
+    await fireEvent.click(anchor, { metaKey: true });
+    await fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    expect(openSpy).toHaveBeenCalledWith(EXTERNAL_URL, '_blank', 'noopener,noreferrer');
+  });
+
+  it('treats middle clicks as new tab navigation', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL });
+
+    await fireEvent(
+      anchor,
+      new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }),
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    expect(openSpy).toHaveBeenCalledWith(EXTERNAL_URL, '_blank', 'noopener,noreferrer');
+  });
+
+  it('ignores same-host, download, and mailto links', async () => {
+    render(ExternalLinkWarning);
+    const sameHost = insertAnchor({ href: `${window.location.origin}/internal` });
+    const download = insertAnchor({ href: EXTERNAL_URL, download: '' });
+    const mailto = insertAnchor({ href: 'mailto:someone@example.org' });
+
+    for (const anchor of [sameHost, download, mailto]) {
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      await fireEvent(anchor, event);
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(screen.queryByTestId('external-link-warning')).not.toBeInTheDocument();
+  });
+
+  it('logs warning_shown, cancelled, and confirmed navigation events', async () => {
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL, target: '_blank' });
+
+    await fireEvent.click(anchor);
+    expect(log).toHaveBeenCalledWith({
+      event_type: 'NAVIGATION',
+      action: 'external_link.warning_shown',
+      metadata: { url: EXTERNAL_URL, newTab: true },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(log).toHaveBeenCalledWith({
+      event_type: 'NAVIGATION',
+      action: 'external_link.cancelled',
+      metadata: { url: EXTERNAL_URL },
+    });
+
+    await fireEvent.click(anchor);
+    await fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    expect(log).toHaveBeenCalledWith({
+      event_type: 'NAVIGATION',
+      action: 'external_link.confirmed',
+      metadata: { url: EXTERNAL_URL, newTab: true },
+    });
+    const cancelLogs = vi
+      .mocked(log)
+      .mock.calls.filter(([event]) => (event as { action?: string }).action?.endsWith('cancelled'));
+    expect(cancelLogs.length).toBe(1);
+  });
+
+  it('uses configured strings when provided', async () => {
+    config.branding.externalLinkWarning = {
+      ...emptyWarningConfig(),
+      title: 'Custom title',
+      message: 'Custom message',
+      okText: 'Continue',
+      cancelText: 'Stay',
+    };
+    render(ExternalLinkWarning);
+    const anchor = insertAnchor({ href: EXTERNAL_URL });
+
+    await fireEvent.click(anchor);
+
+    expect(screen.getByText('Custom title')).toBeInTheDocument();
+    expect(screen.getByText(/Custom message/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stay' })).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(assignSpy).toHaveBeenCalledWith(EXTERNAL_URL);
+  });
+});

--- a/tests/component/setup.ts
+++ b/tests/component/setup.ts
@@ -41,3 +41,30 @@ if (typeof globalThis.localStorage === 'undefined') {
     writable: true,
   });
 }
+
+// happy-dom does not implement the Web Animations API, which Skeleton's Modal
+// (zag-js) calls when opening/closing. Provide a stub whose animations complete
+// immediately so components that wait on `finished`/`onfinish` can settle.
+if (typeof Element !== 'undefined' && typeof Element.prototype.animate === 'undefined') {
+  class ImmediateAnimation {
+    finished: Promise<ImmediateAnimation> = Promise.resolve(this);
+    #onfinish: (() => void) | null = null;
+    get onfinish() {
+      return this.#onfinish;
+    }
+    set onfinish(callback: (() => void) | null) {
+      this.#onfinish = callback;
+      if (callback) queueMicrotask(callback);
+    }
+    play() {}
+    pause() {}
+    finish() {}
+    cancel() {}
+    reverse() {}
+    addEventListener(type: string, listener: () => void) {
+      if (type === 'finish') queueMicrotask(listener);
+    }
+    removeEventListener() {}
+  }
+  Element.prototype.animate = () => new ImmediateAnimation() as unknown as Animation;
+}

--- a/tests/end-to-end/navigation/external-link-warning.test.ts
+++ b/tests/end-to-end/navigation/external-link-warning.test.ts
@@ -1,0 +1,86 @@
+import { expect } from '@playwright/test';
+import { test, mockApiConfig } from '../custom-context';
+import { userIsLoggedIn } from '../utils';
+import type { Branding } from '../../../src/lib/models/Configuration';
+import * as config from '../../../src/lib/assets/configuration.json' with { type: 'json' };
+
+//TypeScript is confused by the JSON import so I am fixing it here
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+const branding: Branding = JSON.parse(JSON.stringify((config as any).default));
+const externalLink = branding.footer.links.find((link) => link.newTab && /^https?:/.test(link.url));
+if (!externalLink) throw new Error('Expected an external newTab link in footer config');
+const expectedTitle = branding.externalLinkWarning?.title || `Leaving ${branding.applicationName}`;
+
+test.describe('External link warning', () => {
+  test.use({ storageState: 'tests/end-to-end/.auth/generalUser.json' });
+
+  test.beforeEach(async ({ page }) => {
+    await mockApiConfig(page, {
+      features: [{ name: 'CONFIRM_EXTERNAL_NAVIGATION', value: 'true' }],
+    });
+  });
+
+  test('Clicking an external footer link opens the warning modal instead of navigating', async ({
+    page,
+  }) => {
+    // Given
+    await page.goto('/');
+    await userIsLoggedIn(page);
+    // When
+    await page.locator('#main-footer').getByRole('link', { name: externalLink.title }).click();
+    // Then
+    const modal = page.getByTestId('external-link-warning');
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(expectedTitle);
+    await expect(page).toHaveURL('/');
+  });
+
+  test('Cancel closes the modal and stays on the page', async ({ page }) => {
+    // Given
+    await page.goto('/');
+    await userIsLoggedIn(page);
+    await page.locator('#main-footer').getByRole('link', { name: externalLink.title }).click();
+    // When
+    await page
+      .getByRole('button', { name: branding.externalLinkWarning?.cancelText || 'Cancel' })
+      .click();
+    // Then
+    await expect(page.getByTestId('external-link-warning')).not.toBeVisible();
+    await expect(page).toHaveURL('/');
+    expect(page.context().pages().length).toBe(1);
+  });
+
+  test('OK opens the external site in a new tab', async ({ page }) => {
+    // Given
+    const externalOrigin = new URL(externalLink.url).origin;
+    await page.context().route(`${externalOrigin}/**`, (route) =>
+      route.fulfill({
+        body: '<html><body>external stub</body></html>',
+        contentType: 'text/html',
+      }),
+    );
+    await page.goto('/');
+    await userIsLoggedIn(page);
+    await page.locator('#main-footer').getByRole('link', { name: externalLink.title }).click();
+    // When
+    // The new tab is opened with noopener, so wait on the context, not a page popup event
+    const newPagePromise = page.context().waitForEvent('page');
+    await page.getByRole('button', { name: branding.externalLinkWarning?.okText || 'OK' }).click();
+    // Then
+    const newPage = await newPagePromise;
+    await newPage.waitForLoadState();
+    expect(newPage.url()).toBe(externalLink.url);
+    await expect(page.getByTestId('external-link-warning')).not.toBeVisible();
+  });
+
+  test('Internal navigation does not trigger the warning', async ({ page }) => {
+    // Given
+    await page.goto('/');
+    await userIsLoggedIn(page);
+    // When
+    await page.locator('#nav-link-help').click();
+    // Then
+    await expect(page).toHaveURL('/help');
+    await expect(page.getByTestId('external-link-warning')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional confirmation modal before navigating to external websites.
  - Supports canceling navigation or confirming it in the current tab or a new tab.
  - Modifier-clicks and middle-clicks are handled appropriately.
  - Internal, downloadable, and email links are unaffected.
  - Warning text and button labels can be customized through branding configuration.
  - The feature can be enabled or disabled through configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->