### PR TITLE
[ALS-9306] Add a copy button to code blocks

### DIFF
--- a/src/lib/components/CodeBlock.svelte
+++ b/src/lib/components/CodeBlock.svelte
@@ -16,6 +16,7 @@
 </script>
 
 <script lang="ts">
+  import CopyButton from '$lib/components/buttons/CopyButton.svelte';
   import type { CodeBlockProps } from '$lib/models/CodeBlock';
 
   let { code = '', lang = 'console', theme = 'dark-plus' }: CodeBlockProps = $props();
@@ -24,7 +25,13 @@
   const generatedHtml = shiki.codeToHtml(code, { lang, theme });
 </script>
 
-<div class="code-block">
+<div class="code-block relative">
+  <CopyButton
+    useIcon
+    itemToCopy={code}
+    data-testid="code-block-copy"
+    class="absolute top-2 right-2 text-surface-300"
+  />
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
   {@html generatedHtml}
 </div>

--- a/src/lib/components/buttons/CopyButton.svelte
+++ b/src/lib/components/buttons/CopyButton.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Popover from '$lib/components/Popover.svelte';
-  import { debounce } from '$lib/utilities/Forms';
 
   interface Props {
     itemToCopy: string;
@@ -26,22 +25,21 @@
     oncopy = () => {},
   }: Props = $props();
 
-  // svelte-ignore state_referenced_locally
-  let activeIcon: string = $state(icon);
-  // svelte-ignore state_referenced_locally
-  let activeButtonText: string = $state(text);
+  let copied = $state(false);
+  let resetTimer: ReturnType<typeof setTimeout>;
 
-  function updateButton() {
-    if (useIcon) {
-      const iconText = icon;
-      debounce(() => (activeIcon = iconText), 4500)();
-      activeIcon = altIcon;
-    } else {
-      const btnText = text;
-      debounce(() => (activeButtonText = btnText), 4500)();
-      activeButtonText = altText;
+  const activeIcon = $derived(copied ? altIcon : icon);
+  const activeButtonText = $derived(copied ? altText : text);
+
+  async function updateButton() {
+    try {
+      await navigator.clipboard.writeText(itemToCopy);
+    } catch {
+      return;
     }
-    navigator.clipboard.writeText(itemToCopy);
+    clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => (copied = false), 4500);
+    copied = true;
     oncopy();
   }
 </script>

--- a/tests/component/CodeBlock.test.ts
+++ b/tests/component/CodeBlock.test.ts
@@ -46,4 +46,16 @@ describe('CodeBlock', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(code);
     expect(button.querySelector('i')).toHaveClass('fa-square-check');
   });
+
+  it('keeps the idle icon when the clipboard write is rejected', async () => {
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValue(new Error('copy denied'));
+    render(CodeBlock, { code, lang: 'python' });
+
+    const button = screen.getByTestId('code-block-copy-btn');
+    await fireEvent.click(button);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(code);
+    expect(button.querySelector('i')).toHaveClass('fa-copy');
+    expect(button.querySelector('i')).not.toHaveClass('fa-square-check');
+  });
 });

--- a/tests/component/CodeBlock.test.ts
+++ b/tests/component/CodeBlock.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+
+import CodeBlock from '$lib/components/CodeBlock.svelte';
+
+const code = 'print("hello world")';
+
+describe('CodeBlock', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn() },
+      configurable: true,
+    });
+    // happy-dom has no Web Animations API; the Popover's fade transition needs it
+    Element.prototype.animate = vi.fn().mockReturnValue({
+      cancel: vi.fn(),
+      finish: vi.fn(),
+      finished: Promise.resolve(),
+    });
+  });
+
+  it('renders syntax highlighted code', () => {
+    const { container } = render(CodeBlock, { code, lang: 'python' });
+
+    const pre = container.querySelector('pre.shiki');
+    expect(pre).toBeInTheDocument();
+    expect(pre).toHaveTextContent('print("hello world")');
+  });
+
+  it('shows a copy button', () => {
+    render(CodeBlock, { code, lang: 'python' });
+
+    const button = screen.getByTestId('code-block-copy-btn');
+    expect(button).toBeVisible();
+    expect(button.querySelector('i')).toHaveClass('fa-copy');
+  });
+
+  it('copies the raw code to the clipboard and shows confirmation', async () => {
+    render(CodeBlock, { code, lang: 'python' });
+
+    const button = screen.getByTestId('code-block-copy-btn');
+    await fireEvent.click(button);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(code);
+    expect(button.querySelector('i')).toHaveClass('fa-square-check');
+  });
+});

--- a/tests/end-to-end/api/test.ts
+++ b/tests/end-to-end/api/test.ts
@@ -133,6 +133,24 @@ test.describe('API page', () => {
     await expect(copyButton).toContainText('Copied!');
     //expect(await page.evaluate(() => navigator.clipboard.readText())).toEqual(mockUser.token);
   });
+  test('Code block copy button copies code and shows confirmation', async ({ page }) => {
+    // Given
+    await page.goto('/analyze/api');
+    await userIsLoggedIn(page);
+
+    // When
+    const copyButton = page.getByTestId('code-block-copy-btn').first();
+
+    // Then
+    await expect(copyButton).toBeVisible();
+    await expect(copyButton.locator('i')).toHaveClass(/fa-copy/);
+
+    // When
+    await copyButton.click();
+
+    // Then
+    await expect(copyButton.locator('i')).toHaveClass(/fa-square-check/);
+  });
   test('Token is visible when reveal button is clicked', async ({ page }) => {
     // Given
     await page.goto('/analyze/api');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy button to code blocks to quickly copy displayed code.
  * Includes clear visual feedback on successful copy (success icon), with safe handling when copying fails.
* **Tests**
  * Added component and end-to-end coverage to verify code rendering, copy-to-clipboard behavior, and the success icon state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->