### PR TITLE
[CHORE] Adopt Node majors deliberately, not via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: '[pnpm] '
+    ignore:
+      # Node majors are adopted deliberately as a release engineering decision
+      # (next: Node 26 once it reaches LTS, ~Oct 2026), keeping .nvmrc, the
+      # Dockerfiles, and @types/node in sync in a single change.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'docker'
     directory: '/'
@@ -13,3 +19,7 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: '[docker] '
+    ignore:
+      # See the @types/node note above - runtime majors are upgraded manually.
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "pic-sure-frontend",
   "version": "3.0.0",
   "private": true,
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
Encodes the Node-major upgrade policy in the repo instead of leaving it as tribal knowledge in closed Dependabot PRs:

- **`.github/dependabot.yml`**: ignore `semver-major` updates for the `node` Docker base image and `@types/node`. Runtime majors are a release engineering decision — when we adopt one, `.nvmrc`, both Dockerfiles, and `@types/node` should move together in a single deliberate change, not via piecemeal bot PRs.
- **`package.json`**: add `"engines": { "node": "24.x" }` so local environments hard-fail (pnpm) when they drift from CI/prod, which both pin 24.14.1 via `.nvmrc`. If your local Node isn't 24: `nvm install` in the repo root picks it up from `.nvmrc`.

Next planned adoption is Node 26 once it reaches LTS (~Oct 2026) — tracked separately. Closes the standing Dependabot PRs #682 and #693 in favor of that planned upgrade.