### PR TITLE
[CHORE] Harden Dockerfiles: pin runtime node, replace httpd.conf sed chain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,24 +17,22 @@ RUN pnpm build \
 # Step 2: Serve the app with httpd
 FROM httpd:2.4.68-alpine3.23@sha256:4a15e9c73f25334bc03cfb3c692c9adfc103bb46ca89cee1f0b9a5fcbc7b21f6
 
-# Keeping these unpinned reduces the risk of alpine pulling the image and breaking deployment
+# apk pins rot (Alpine keeps only the newest package per branch), so the base
+# image's own libs are refreshed via the weekly digest bumps instead. node is
+# copied from the digest-pinned builder so build and runtime cannot drift.
 RUN apk add --no-cache \
-  libexpat \
-  nodejs \
-  openssl \
-  sed \
-  supervisor \
-  zlib
+  libstdc++ \
+  supervisor
+COPY --from=builder /usr/local/bin/node /usr/local/bin/node
 
+COPY httpd-picsure.conf ${HTTPD_PREFIX}/conf/extra/httpd-picsure.conf
 RUN mkdir -p ${HTTPD_PREFIX}/cert /usr/local/apache2/logs/ssl_mutex \
-  && sed -i '/^#Include conf.extra.httpd-vhosts.conf/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule proxy_module/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule proxy_http_module/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule proxy_connect_module/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule ssl_module modules\/mod_ssl.so/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule rewrite_module modules\/mod_rewrite.so/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule socache_shmcb_module modules\/mod_socache_shmcb.so/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i 's/Options Indexes FollowSymLinks/Options -Indexes +FollowSymLinks/' ${HTTPD_PREFIX}/conf/httpd.conf
+  && echo "Include conf/extra/httpd-picsure.conf" >> ${HTTPD_PREFIX}/conf/httpd.conf \
+  && httpd -t \
+  && httpd -M | grep -q proxy_http_module \
+  && httpd -M | grep -q ssl_module \
+  && httpd -M | grep -q rewrite_module \
+  && node --version
 
 WORKDIR /app
 RUN mkdir -p logs

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,29 +10,28 @@ COPY . .
 # Step 2: Serve the app with httpd
 FROM httpd:2.4.68-alpine3.23@sha256:4a15e9c73f25334bc03cfb3c692c9adfc103bb46ca89cee1f0b9a5fcbc7b21f6
 
-# Keeping these unpinned reduces the risk of alpine pulling the image and breaking deployment
+# apk pins rot (Alpine keeps only the newest package per branch), so the base
+# image's own libs are refreshed via the weekly digest bumps instead. node and
+# npm are copied from the digest-pinned builder so build and runtime cannot drift.
 RUN apk add --no-cache \
-  libexpat \
-  nodejs \
-  npm \
-  openssl \
-  pnpm \
-  sed \
-  supervisor \
-  zlib
+  libstdc++ \
+  supervisor
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 #TODO: volume mount the certs
 RUN mkdir -p ${HTTPD_PREFIX}/cert /usr/local/apache2/logs/ssl_mutex
 COPY cert ${HTTPD_PREFIX}/cert
 COPY httpd-vhosts.conf ${HTTPD_PREFIX}/conf/extra/httpd-vhosts.conf
 
-RUN sed -i '/^#Include conf.extra.httpd-vhosts.conf/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule proxy_module/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule proxy_http_module/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule proxy_connect_module/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule ssl_module modules\/mod_ssl.so/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule rewrite_module modules\/mod_rewrite.so/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf \
-  && sed -i '/^#LoadModule socache_shmcb_module modules\/mod_socache_shmcb.so/s/^#//' ${HTTPD_PREFIX}/conf/httpd.conf
+COPY httpd-picsure.conf ${HTTPD_PREFIX}/conf/extra/httpd-picsure.conf
+RUN echo "Include conf/extra/httpd-picsure.conf" >> ${HTTPD_PREFIX}/conf/httpd.conf \
+  && httpd -t \
+  && httpd -M | grep -q proxy_http_module \
+  && httpd -M | grep -q ssl_module \
+  && httpd -M | grep -q rewrite_module \
+  && node --version \
+  && npm --version
 
 WORKDIR /app
 RUN mkdir -p logs

--- a/httpd-picsure.conf
+++ b/httpd-picsure.conf
@@ -1,0 +1,16 @@
+# Modules and overrides PIC-SURE needs on top of the stock httpd.conf.
+# Loaded via a single Include appended to httpd.conf by the Dockerfiles;
+# the build asserts these modules are live, so a drifting base config
+# fails the build instead of silently shipping without proxy/SSL.
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_connect_module modules/mod_proxy_connect.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+<Directory "/usr/local/apache2/htdocs">
+    Options -Indexes +FollowSymLinks
+</Directory>
+
+Include conf/extra/httpd-vhosts.conf


### PR DESCRIPTION
Fixes two smells in the httpd stage of both Dockerfiles (spotted while auditing against Docker best practices):

**1. Unpinned apk `nodejs` meant build/runtime Node drift.** The builder compiles on the digest-pinned `node:24.18.0`, but the SSR process ran whatever Alpine's repo shipped (currently 24.17.0, moving on its own). Alpine repos keep only the newest package per branch, so apk pins would rot — instead, `node` (and `npm` in dev) are now `COPY --from` the digest-pinned builder, making drift impossible. `libexpat`/`openssl`/`zlib`/`sed` are dropped from apk: the base image already ships them, and the weekly Dependabot digest bumps refresh them reproducibly.

**2. The 8-command `sed -i` chain over `httpd.conf` fails silently.** `sed -i` with a non-matching pattern exits 0 — if an httpd image bump rewords a config comment, the build goes green and the proxy/SSL modules just never load. Replaced with a checked-in `httpd-picsure.conf` (LoadModules, `Options -Indexes`, vhosts Include) enabled by a single appended `Include`, plus build-time `httpd -t` and `httpd -M` assertions so a config regression now **fails the build**.

**Validation** (old image vs new, built locally):
- `httpd -M` module sets byte-identical
- Directory listing still blocked (403 in both); dev now also gets `-Indexes` (previously prod-only, almost certainly an oversight)
- Prod boot: supervisord + httpd + `node build` SSR all healthy, HTTP 200 from the SSR port
- Dev boot: supervisord + httpd + `npm run dev` (Vite ready) with harness vhosts + a self-signed cert

**Trade-off to be aware of:** the prod image grows 361MB → 420MB because the official node binary (120MB, bundles full ICU) replaces Alpine's stripped 48MB distro build. If that matters more than exact version parity, the lean alternative is keeping apk `nodejs` plus a build-time assertion that its major matches the builder's — happy to switch.
